### PR TITLE
run grunt package on npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/charwking/movie-club/issues"
   },
   "scripts": {
-    "test": "node -e \"require('grunt').tasks(['compile']);\""
+    "test": "node -e \"require('grunt').tasks(['package']);\""
   },
   "homepage": "https://github.com/charwking/movie-club",
   "devDependencies": {


### PR DESCRIPTION
This changes the `npm test` command so that it packages the build instead of just compiling it. This is helpful because we want to make sure packaging the code works before we accept it into the master branch.