### PR TITLE
Use bower for run-time dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+bower_components
 node_modules
 
 *.log

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "movie-club",
+  "version": "1.0.0",
+  "homepage": "https://github.com/charwking/movie-club",
+  "authors": [
+    "Charles King"
+  ],
+  "license": "GPLv3",
+  "dependencies": {
+    "angular": "1.3.15",
+    "angular-google-analytics": "0.0.13",
+    "angular-ui-router": "0.2.14"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "url": "https://github.com/charwking/movie-club/issues"
   },
   "scripts": {
-    "test": "node -e \"require('grunt').tasks(['package']);\""
+    "test": "node -e \"require('grunt').tasks(['package']);\"",
+    "postinstall": "node_modules/bower/bin/bower install"
   },
   "homepage": "https://github.com/charwking/movie-club",
   "devDependencies": {
     "angular-mocks": "1.3.15",
+    "bower": "1.4.1",
     "grunt": "0.4.5",
     "grunt-autoprefixer": "3.0.0",
     "grunt-cache-bust": "0.4.13",
@@ -37,10 +39,5 @@
     "karma-jasmine": "0.3.5",
     "karma-phantomjs-launcher": "0.1.4",
     "load-grunt-tasks": "3.1.0"
-  },
-  "dependencies": {
-    "angular": "1.3.15",
-    "angular-google-analytics": "0.0.5",
-    "angular-ui-router": "0.2.13"
   }
 }

--- a/project.conf.js
+++ b/project.conf.js
@@ -2,6 +2,7 @@ var dirs = {
     output: 'dist/',
     source: 'src/',
     test: 'test/',
+    bower: 'bower_components/',
     npm: 'node_modules/'
 };
 
@@ -31,9 +32,9 @@ module.exports = {
         ],
         jsAppTestFiles: dirs.test + '**/*.js',
         jsThirdPartyClientFiles: [
-            dirs.npm + 'angular/angular.js',
-            dirs.npm + 'angular-ui-router/release/angular-ui-router.js',
-            dirs.npm + 'angular-google-analytics/dist/angular-google-analytics.js'
+            dirs.bower + 'angular/angular.js',
+            dirs.bower + 'angular-ui-router/release/angular-ui-router.js',
+            dirs.bower + 'angular-google-analytics/dist/angular-google-analytics.js'
         ],
         jsThirdPartyTestFiles: [
             dirs.npm + 'angular-mocks/angular-mocks.js'


### PR DESCRIPTION
Closes #19 

I decided to use `bower` instead. There's no CDN for all the libraries, so bower was the quickest, easiest solution.