### PR TITLE
track url params in google analytics

### DIFF
--- a/src/app/app.config.js
+++ b/src/app/app.config.js
@@ -12,7 +12,7 @@
         // setup analytics
         AnalyticsProvider.setAccount('UA-52798669-1');
         AnalyticsProvider.trackPages(true);
-        // AnalyticsProvider.trackUrlParams(true);
+        AnalyticsProvider.trackUrlParams(true);
         AnalyticsProvider.trackPrefix('movie-club');
     }
 


### PR DESCRIPTION
Switching to bower allowed me to update the version of the `angular-google-analytics` library, which allowed the `trackUrlParams` option. Let's turn it on.