### PR TITLE
Load font via https

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="shortcut icon" type="image/ico" href="images/favicon.ico" />
         <link href="css/app.css" type="text/css" media="screen, projection" rel="stylesheet"/>
-        <link href="http://fonts.googleapis.com/css?family=Fira+Sans:300,400,500,700,300italic,400italic,500italic,700italic" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Fira+Sans:300,400,500,700,300italic,400italic,500italic,700italic" rel="stylesheet" type="text/css">
         <title>Movie Club</title>
     </head>
 


### PR DESCRIPTION
Loads font via `https` instead of `http` so that it works when deployed.