### PR TITLE
Allow longer javascript lines

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -13,7 +13,7 @@
     "requireOperatorBeforeLineBreak": true,
     "requireCamelCaseOrUpperCaseIdentifiers": true,
     "maximumLineLength": {
-      "value": 100,
+      "value": 120,
       "allowComments": true,
       "allowRegex": true
     },


### PR DESCRIPTION
Updates the `.jsrsc` file to allow for longer javascript lines.