### PR TITLE
Prevent double submission of forms

### DIFF
--- a/src/auth/login.html
+++ b/src/auth/login.html
@@ -29,10 +29,7 @@
             />
             </br>
 
-            <button
-                ng-click="vm.login()"
-                ng-disabled="!vm.loginForm.$valid"
-            >
+            <button ng-disabled="!vm.loginForm.$valid">
                 <i ng-if="vm.isLoading" class="fa fa-spin fa-spinner"></i> Submit
             </button>
 

--- a/src/auth/register.html
+++ b/src/auth/register.html
@@ -55,10 +55,7 @@
             />
             </br>
 
-            <button
-                ng-click="vm.register()"
-                ng-disabled="!vm.registrationForm.$valid"
-            >
+            <button ng-disabled="!vm.registrationForm.$valid">
                 <i ng-if="vm.isSubmitting" class="fa fa-spin fa-spinner"></i> Submit
             </button>
 


### PR DESCRIPTION
The login and registration forms had both a `ng-submit` and a button with an `ng-click` that was causing the forms to be submitted twice when the button was clicked. This removes the extra `ng-click`s.