### PR TITLE
Adds user management page

### DIFF
--- a/FIREBASE.md
+++ b/FIREBASE.md
@@ -21,9 +21,16 @@ In general, my strategy is to keep permissions restrictive until a use-case appe
       }
     },
 
+    "admins": {
+      "$userId": {
+        ".validate": "newData.isBoolean()"
+      }
+    },
+
     "users": {
 
       ".read": "true",
+      ".write": "root.child('admins').child(auth.uid).val() === true",
 
       "$userId": {
 
@@ -37,4 +44,5 @@ In general, my strategy is to keep permissions restrictive until a use-case appe
     }
   }
 }
+
 ```

--- a/src/app/app.module.js
+++ b/src/app/app.module.js
@@ -7,6 +7,7 @@
             'movieClub.dashboard',
             'movieClub.nav',
             'movieClub.users',
+            'movieClub.userManagement',
             'movieClub.userMovies'
         ]);
 

--- a/src/userManagement/userManagement.controller.js
+++ b/src/userManagement/userManagement.controller.js
@@ -1,0 +1,22 @@
+(function (angular) {
+    'use strict';
+
+    angular
+        .module('movieClub.userManagement')
+        .controller('UserManagementController', UserManagementController);
+
+    function UserManagementController(users) {
+        var vm = this;
+
+        // vars
+        vm.users = users;
+
+        // funcs
+        vm.deleteUser = deleteUser;
+
+        function deleteUser(user) {
+            vm.users.$remove(user);
+        }
+    }
+
+}(window.angular));

--- a/src/userManagement/userManagement.html
+++ b/src/userManagement/userManagement.html
@@ -1,0 +1,14 @@
+<section>
+    <br/>
+
+    <h2>Users</h2>
+
+    <div>
+        Note: This only removes the app-specific user data. You must still go in and remove the user in Firebase Forge.
+    </div>
+    </br>
+
+    <div ng-repeat="user in userManagementVm.users | orderBy:'username'">
+        {{user.username}} (<a ng-click="userManagementVm.deleteUser(user)" href="#">delete</a>)
+    </div>
+</section>

--- a/src/userManagement/userManagement.module.js
+++ b/src/userManagement/userManagement.module.js
@@ -1,0 +1,9 @@
+(function (angular) {
+    'use strict';
+
+    angular
+        .module('movieClub.userManagement', [
+            'movieClub.core'
+        ]);
+
+}(window.angular));

--- a/src/userManagement/userManagement.routes.js
+++ b/src/userManagement/userManagement.routes.js
@@ -1,0 +1,23 @@
+(function (angular) {
+    'use strict';
+
+    angular
+        .module('movieClub.userManagement')
+        .config(appConfig);
+
+    function appConfig($stateProvider) {
+
+        $stateProvider
+            .state('userManagement', {
+                controller: 'UserManagementController as userManagementVm',
+                templateUrl: 'userManagement/userManagement.html',
+                url: '/admin/user-management',
+                resolve: {
+                    users: function (usersApi) {
+                        return usersApi.getAll().$loaded();
+                    }
+                }
+            });
+    }
+
+}(window.angular));


### PR DESCRIPTION
This adds a very simple user management page to `/admin/user-management` that lets an admin delete users. This was mostly to help me clean up all the test users I was creating. It doesn't completely delete them, due to some firebase limitations, but deletes the extra data we store anytime a user registers.

This left to do:
* Add a link to this page somewhere.
* Only allow admins to browse to it. (If non-admins browse to it, they can see the page and can click on the delete links, but nothing happens.)