### PR TITLE
Add users to host meeting page

### DIFF
--- a/FIREBASE.md
+++ b/FIREBASE.md
@@ -10,14 +10,6 @@ In general, my strategy is to keep permissions restrictive until a use-case appe
 {
   "rules": {
 
-    "propertyStore": {
-      ".read": true,
-
-      "clubName": {
-        ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 50"
-      }
-    },
-
     "adminStore": {
 
       ".read": true,
@@ -27,10 +19,19 @@ In general, my strategy is to keep permissions restrictive until a use-case appe
       }
     },
 
+    "propertyStore": {
+
+      ".read": true,
+
+      "clubName": {
+        ".validate": "newData.isString() && newData.val().length > 0 && newData.val().length <= 50"
+      }
+    },
+
     "users": {
 
       ".read": "true",
-      ".write": "root.child('admins').child(auth.uid).val() === true",
+      ".write": "root.child('adminStore').child(auth.uid).val() === true",
 
       "$userId": {
 
@@ -44,6 +45,9 @@ In general, my strategy is to keep permissions restrictive until a use-case appe
     },
 
     "userMovies": {
+
+      ".read": "root.child('adminStore').child(auth.uid).val() === true",
+
       "$userId": {
         "movies": {
 
@@ -67,5 +71,4 @@ In general, my strategy is to keep permissions restrictive until a use-case appe
     }
   }
 }
-
 ```

--- a/src/hostMeeting/hostMeeting.controller.js
+++ b/src/hostMeeting/hostMeeting.controller.js
@@ -5,8 +5,26 @@
         .module('movieClub')
         .controller('HostMeetingController', HostMeetingController);
 
-    function HostMeetingController($state, adminStore, authApi, users) {
+    function HostMeetingController(users) {
         var vm = this;
+        vm.presentUsers = [];
+        vm.absentUsers = _.map(users, function (user) {
+            return {username: user.username, id: user.$id};
+        });
+
+        vm.moveUserToPresent = moveUserToPresent;
+        vm.moveUserToAbsent = moveUserToAbsent;
+
+        function moveUserToPresent(user) {
+            _.remove(vm.absentUsers, user);
+            vm.presentUsers.push(user);
+        }
+
+        function moveUserToAbsent(user) {
+            _.remove(vm.presentUsers, user);
+            vm.absentUsers.push(user);
+        }
+
     }
 
 }(window.angular));

--- a/src/hostMeeting/hostMeeting.controller.js
+++ b/src/hostMeeting/hostMeeting.controller.js
@@ -5,12 +5,10 @@
         .module('movieClub')
         .controller('HostMeetingController', HostMeetingController);
 
-    function HostMeetingController(users) {
+    function HostMeetingController(users, userMovies) {
         var vm = this;
         vm.presentUsers = [];
-        vm.absentUsers = _.map(users, function (user) {
-            return {username: user.username, id: user.$id};
-        });
+        vm.absentUsers = getAbsentUsers();
 
         vm.moveUserToPresent = moveUserToPresent;
         vm.moveUserToAbsent = moveUserToAbsent;
@@ -23,6 +21,24 @@
         function moveUserToAbsent(user) {
             _.remove(vm.presentUsers, user);
             vm.absentUsers.push(user);
+        }
+
+        function getNextUserMovie(user) {
+            var userMovieObj = _.find(userMovies, {'$id': user.$id});
+            if (userMovieObj) {
+                return _.find(userMovieObj.movies, {'order': 0});
+            }
+            return null;
+        }
+
+        function getAbsentUsers() {
+            return _.map(users, function (user) {
+                return {
+                    id: user.$id,
+                    username: user.username,
+                    nextMovie: getNextUserMovie(user)
+                };
+            });
         }
 
     }

--- a/src/hostMeeting/hostMeeting.html
+++ b/src/hostMeeting/hostMeeting.html
@@ -7,7 +7,7 @@
         ng-repeat="user in hostMeetingVm.absentUsers | orderBy:'username'"
         ng-click="hostMeetingVm.moveUserToPresent(user)"
     >
-        {{user.username}}
+        {{user.username}} <i ng-if="user.nextMovie" class="fa fa-video-camera"></i>
     </div>
 </section>
 
@@ -17,6 +17,6 @@
         ng-repeat="user in hostMeetingVm.presentUsers | orderBy:'username'"
         ng-click="hostMeetingVm.moveUserToAbsent(user)"
     >
-        {{user.username}}
+        {{user.username}} <i ng-if="user.nextMovie" class="fa fa-video-camera"></i>
     </div>
 </section>

--- a/src/hostMeeting/hostMeeting.html
+++ b/src/hostMeeting/hostMeeting.html
@@ -1,3 +1,22 @@
 <br/>
-<br/>
 <h3>Host a Meeting</h3>
+
+<section>
+    <h2>Absent Users</h2>
+    <div
+        ng-repeat="user in hostMeetingVm.absentUsers | orderBy:'username'"
+        ng-click="hostMeetingVm.moveUserToPresent(user)"
+    >
+        {{user.username}}
+    </div>
+</section>
+
+<section>
+    <h2>Present Users</h2>
+    <div
+        ng-repeat="user in hostMeetingVm.presentUsers | orderBy:'username'"
+        ng-click="hostMeetingVm.moveUserToAbsent(user)"
+    >
+        {{user.username}}
+    </div>
+</section>

--- a/src/hostMeeting/hostMeeting.routes.js
+++ b/src/hostMeeting/hostMeeting.routes.js
@@ -18,6 +18,9 @@
                 resolve: {
                     users: function (usersApi) {
                         return usersApi.getAll().$loaded();
+                    },
+                    userMovies: function (userMoviesApi) {
+                        return userMoviesApi.getAll().$loaded();
                     }
                 }
             });

--- a/src/hostMeeting/hostMeeting.routes.js
+++ b/src/hostMeeting/hostMeeting.routes.js
@@ -13,7 +13,13 @@
                 templateUrl: 'hostMeeting/hostMeeting.html',
                 url: '/admin/host-meeting',
 
-                adminRequired: true
+                adminRequired: true,
+
+                resolve: {
+                    users: function (usersApi) {
+                        return usersApi.getAll().$loaded();
+                    }
+                }
             });
     }
 

--- a/src/userMovies/userMoviesApi.service.js
+++ b/src/userMovies/userMoviesApi.service.js
@@ -7,9 +7,14 @@
 
     function userMoviesApi($firebaseArray, firebaseRef) {
         var factory = {
+            getAll: getAll,
             getAllByUserId: getAllByUserId
         };
         return factory;
+
+        function getAll() {
+            return $firebaseArray(firebaseRef.child('userMovies'));
+        }
 
         function getAllByUserId(userId) {
             return $firebaseArray(firebaseRef.child('userMovies').child(userId).child('movies'));


### PR DESCRIPTION
This adds two lists of users to the host-a-meeting page: Absent users and present users. You can click on a user in either group and it moves to the other. A camera is shown next to each user who has at least one movie entered.

As per usual, this is rough and needs some UI help.

There's still a lot of work left, but this is a start!

![image](https://cloud.githubusercontent.com/assets/5176154/8345984/ea802bca-1abb-11e5-9d46-ac400ceed66b.png)
