### PR TITLE
Fix reording movies in user queue after delete

### DIFF
--- a/src/myMovies/myMovies.controller.js
+++ b/src/myMovies/myMovies.controller.js
@@ -21,10 +21,12 @@
 
         function removeMovie(movie) {
             vm.movies.$remove(movie).then(function () {
-                _.forEach(vm.movies, function (movie, index) {
-                    movie.order = index;
-                    vm.movies.$save(movie);
-                });
+                _(vm.movies)
+                    .sortBy('order')
+                    .forEach(function (movie, index) {
+                        movie.order = index;
+                        vm.movies.$save(movie);
+                    });
             });
         }
 


### PR DESCRIPTION
This fixes #105, which Dustin found today.

When removing a movie from the movie queue, we update the `order` of each movie. The code was assuming the movies in the `vm.movies` array were already sorted by `order`, which is not the case. The fix is to sort them before updating their `order` properties.