### PR TITLE
Dynamically choose firebase instance to use

### DIFF
--- a/src/environment/environment.service.js
+++ b/src/environment/environment.service.js
@@ -1,0 +1,33 @@
+(function (angular) {
+    'use strict';
+
+    angular
+        .module('movieClub')
+        .factory('environmentService', environmentService);
+
+    function environmentService($location) {
+
+        var factory = {
+            get: get,
+            LOCAL: 'local',
+            DEV: 'dev',
+            PROD: 'prod'
+        };
+        return factory;
+
+        function get() {
+            var host = $location.host();
+
+            if (host === 'localhost') {
+                return factory.LOCAL;
+            }
+
+            if (_.startsWith(host, 'dev.')) {
+                return factory.DEV;
+            }
+
+            return factory.PROD;
+        }
+    }
+
+}(window.angular));

--- a/src/environment/environment.service.spec.js
+++ b/src/environment/environment.service.spec.js
@@ -1,0 +1,45 @@
+(function () {
+    'use strict';
+
+    describe('environmentService', function () {
+
+        var $location;
+        var environmentService;
+
+        beforeEach(module('movieClub'));
+        beforeEach(inject(function (_$location_, _environmentService_) {
+            $location = _$location_;
+            environmentService = _environmentService_;
+        }));
+
+        describe('constants', function () {
+
+            it('should expose environment constants with unique values', function () {
+                expect(environmentService.LOCAL).not.toEqual(environmentService.DEV);
+                expect(environmentService.LOCAL).not.toEqual(environmentService.PROD);
+                expect(environmentService.DEV).not.toEqual(environmentService.PROD);
+            });
+        });
+
+        describe('get', function () {
+
+            it('should return LOCAL when host is localhost', function () {
+                spyOn($location, 'host').and.returnValue('localhost');
+
+                expect(environmentService.get()).toBe(environmentService.LOCAL);
+            });
+
+            it('should return DEV when host has dev subdomain', function () {
+                spyOn($location, 'host').and.returnValue('dev.github.com');
+
+                expect(environmentService.get()).toBe(environmentService.DEV);
+            });
+
+            it('should return PROD when host is neither localhost nor has dev subdomain', function () {
+                spyOn($location, 'host').and.returnValue('github.com');
+
+                expect(environmentService.get()).toBe(environmentService.PROD);
+            });
+        });
+    });
+}());

--- a/src/firebase/firebaseRef.service.js
+++ b/src/firebase/firebaseRef.service.js
@@ -5,8 +5,16 @@
         .module('movieClub')
         .factory('firebaseRef', firebaseRef);
 
-    function firebaseRef() {
-        return new Firebase('https://glowing-inferno-1828.firebaseio.com/');
+    function firebaseRef(environmentService) {
+
+        var env = environmentService.get();
+
+        var firebaseUrl =
+            (env === environmentService.LOCAL || env === environmentService.DEV) ?
+            'https://glowing-inferno-1828.firebaseio.com/' :
+            'https://movie-club.firebaseio.com/';
+
+        return new Firebase(firebaseUrl);
     }
 
 }(window.angular, window.Firebase));


### PR DESCRIPTION
This closes #107 and causes the web page to dynamically choose the appropriate firebase instance based on the host. Yeah, once I paused to think about it, this was pretty straightforward.