### PR TITLE
Use https instead of git protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Assuming you're on a mac...
 * Clone the repo:
 
     ```
-    git clone git@github.com:charwking/movie-club.git
+    git clone https://github.com/charwking/movie-club.git 
     ```
 
 * cd into the movie-club directory:


### PR DESCRIPTION
This changes the `README` to use https to clone the repo instead of the `git` protocol. I've heard rumor that people are having trouble cloning the repo while on corporate networks. I think this will fix that.