### PR TITLE
Bug fix

### DIFF
--- a/src/hostMeeting/hostMeeting.controller.js
+++ b/src/hostMeeting/hostMeeting.controller.js
@@ -53,7 +53,7 @@
             var userIndex = _.random(usersWithMovies.length - 1);
             var user = usersWithMovies[userIndex];
             currentMovie.name = user.nextMovie.name;
-            currentMovie.trailerUrl = user.nextMovie.trailerUrl;
+            currentMovie.trailerUrl = user.nextMovie.trailerUrl || null;
             currentMovie.$save();
             currentMovieUser.userId = user.id;
             currentMovieUser.$save();

--- a/src/myMovies/myMovies.html
+++ b/src/myMovies/myMovies.html
@@ -6,7 +6,7 @@
             <input type="text" ng-model="myMoviesVm.newMovieName" placeholder="Movie Title"/>
             
             <label>Movie Trailer:</label>
-            <a ng-href="https://www.youtube.com/results?search_query={{myMoviesVm.newMovieName}}" 
+            <a ng-href="https://www.youtube.com/results?search_query={{myMoviesVm.newMovieName}}+trailer" 
                target="blank" 
                ng-if="myMoviesVm.newMovieName.length > 0" 
                title="Search YouTube">


### PR DESCRIPTION
**Cause**: Movies previously in firebase before this enhancement did not have a `movie.trailerUrl` property.  This caused the value to be undefined.  When a movie was selected from the meeting, it tried to copy that `undefined` property over, however firebase has rules to check and verify it cannot be `undefined`, only `null`.

**Fix**: Check if `trailerUrl` has a value, and if not default to null.