### PR TITLE
Fix bug with whitelisted templates; Add tests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,7 @@
         .module('movieClub', moduleDependencies)
         .config(setDefaultRoute)
         .config(configureAnalytics)
-        .config(sceDelegateProvider)
+        .config(whitelistTemplateSources)
         .run(injectAnalytics)
         .run(handleAuthStates);
 
@@ -27,9 +27,11 @@
         AnalyticsProvider.trackPrefix('movie-club');
     }
 
-    function sceDelegateProvider($sceDelegateProvider) {
-        var whiteList = ['*://www.youtube.com/**'];
-        $sceDelegateProvider.resourceUrlWhitelist(whiteList);
+    function whitelistTemplateSources($sceDelegateProvider) {
+        $sceDelegateProvider.resourceUrlWhitelist([
+            'self',
+            '*://www.youtube.com/**'
+        ]);
     }
 
     function injectAnalytics(Analytics) {

--- a/src/app.spec.js
+++ b/src/app.spec.js
@@ -1,0 +1,85 @@
+(function (angular) {
+    'use strict';
+
+    describe('app', function () {
+
+        describe('$urlRouterProvider', function () {
+
+            var $urlRouterProvider;
+
+            beforeEach(function () {
+                module('ui.router', function (_$urlRouterProvider_) {
+                    $urlRouterProvider = _$urlRouterProvider_;
+                    spyOn($urlRouterProvider, 'when').and.callThrough();
+                });
+                module('movieClub');
+            });
+
+            beforeEach(inject);
+
+            it('should be configured to use the default route when there is none', function () {
+                expect($urlRouterProvider.when).toHaveBeenCalledWith('', '/');
+            });
+        });
+
+        describe('AnalyticsProvider', function () {
+
+            var analyticsProvider;
+
+            beforeEach(function () {
+                module('angular-google-analytics', function (_AnalyticsProvider_) {
+                    analyticsProvider = _AnalyticsProvider_;
+                    spyOn(analyticsProvider, 'setAccount').and.callThrough();
+                    spyOn(analyticsProvider, 'trackPages').and.callThrough();
+                    spyOn(analyticsProvider, 'trackUrlParams').and.callThrough();
+                    spyOn(analyticsProvider, 'trackPrefix').and.callThrough();
+                });
+                module('movieClub');
+            });
+
+            beforeEach(inject);
+
+            it('should be configured with the correct analytics account', function () {
+                expect(analyticsProvider.setAccount).toHaveBeenCalledWith('UA-52798669-1');
+            });
+
+            it('should be configured to track pages', function () {
+                expect(analyticsProvider.trackPages).toHaveBeenCalledWith(true);
+            });
+
+            it('should be configured to track url params', function () {
+                expect(analyticsProvider.trackUrlParams).toHaveBeenCalledWith(true);
+            });
+
+            it('should be configured to use the movie-club prefix', function () {
+                expect(analyticsProvider.trackPrefix).toHaveBeenCalledWith('movie-club');
+            });
+        });
+
+        describe('$sceDelegateProvider', function () {
+
+            var $sceDelegateProvider;
+
+            beforeEach(function () {
+                module('ng', function (_$sceDelegateProvider_) {
+                    $sceDelegateProvider = _$sceDelegateProvider_;
+                    spyOn($sceDelegateProvider, 'resourceUrlWhitelist').and.callThrough();
+                });
+                module('movieClub');
+            });
+
+            beforeEach(inject);
+
+            it('should be configured to whitelist calls from the current domain', function () {
+                var lastCall = $sceDelegateProvider.resourceUrlWhitelist.calls.mostRecent();
+                expect(lastCall.args[0]).toContain('self');
+            });
+
+            it('should be configured to whitelist youtube URLs', function () {
+                var lastCall = $sceDelegateProvider.resourceUrlWhitelist.calls.mostRecent();
+                expect(lastCall.args[0]).toContain('*://www.youtube.com/**');
+            });
+        });
+    });
+
+}(window.angular));


### PR DESCRIPTION
This fixes a minor bug that would have prevented templates from being loaded from the domain where the movie-club website was running. This doesn't affect us now, since all the templates are preemptively cached, but doesn't hurt to fix.

It also gives me an excuse to add tests around the `angular.config` blocks. Testing config blocks takes a unique approach that required some research (read: googling). I also got a chance to use jasmine's [.calls.mostRecent()](https://jasmine.github.io/2.3/introduction.html#section-31) method for the first time in a totally worthwhile situation.

The run blocks still need tests, but I'll leave that for another day (or another person).