### PR TITLE
Make propertiesApi act as non-firebase api

### DIFF
--- a/src/dashboard/dashboard.controller.js
+++ b/src/dashboard/dashboard.controller.js
@@ -8,7 +8,7 @@
     function DashboardController(currentMovie, properties, users) {
         var vm = this;
         vm.currentMovie = currentMovie;
-        vm.properties = properties;
+        vm.clubNameProp = _.find(properties, {id: 'clubName'});
         vm.usernames = _.pluck(users, 'username');
     }
 

--- a/src/dashboard/dashboard.controller.spec.js
+++ b/src/dashboard/dashboard.controller.spec.js
@@ -1,0 +1,35 @@
+(function (angular) {
+    'use strict';
+
+    describe('DashboardController', function () {
+
+        var subject;
+
+        beforeEach(function () {
+            module('movieClub');
+            inject(function ($controller) {
+                subject = $controller('DashboardController', {
+                    currentMovie: 'current movie value',
+                    properties: [{id: 'clubDesc'}, {id: 'clubName'}, {id: 'clubOwner'}],
+                    users: [{username: 'Tom'}, {username: 'Dick'}, {username: 'Harry'}]
+                });
+            });
+        });
+
+        describe('after initialization', function () {
+
+            it('should expose the currentMovie', function () {
+                expect(subject.currentMovie).toEqual('current movie value');
+            });
+
+            it('should expose the clubName property', function () {
+                expect(subject.clubNameProp).toEqual({id: 'clubName'});
+            });
+
+            it('should expose the usernames', function () {
+                expect(subject.usernames).toEqual(['Tom', 'Dick', 'Harry']);
+            });
+        });
+    });
+
+}(window.angular));

--- a/src/dashboard/dashboard.html
+++ b/src/dashboard/dashboard.html
@@ -18,18 +18,18 @@
 <section class="about-club-section">
 
     <h2>About our Club</h2>
-    
-    <h3 ng-if="dashboardVm.properties.clubName">
-        Welcome to {{dashboardVm.properties.clubName}}
+
+    <h3 ng-if="dashboardVm.clubNameProp">
+        Welcome to {{dashboardVm.clubNameProp.value}}
     </h3>
-    
+
     <p>Movie Club began after a lengthy discussion between coworkers about movies we watched, loved, and hated. It was a surprise to learn that many had missed out on what some considered “ the classics”, others were not up to speed with newer releases, and some people had hardly watched any decent movies in their whole life...
 
 We decided to give ourselves an excuse to watch these flicks and the official Movie Club was born! We started in the old-fashioned way – each submitting one movie on a paper ticket and pulling one ticket out of the box each meeting. The meetings are run like a book club; we acquire the movie with our own resources, watch the movie on our own time, discuss the movie together over lunch, and then draw another movie before we depart. Movie Club began as an every-other week event, but popular vote demanded we draw movies and meet once a week! The first round "original 11" movies are represented in this websites header image.
 
 We now have a fully-functioning website and over 20 participants! New faces and new movies are always welcome! Please check out and contribute to our gitHub repo.</p>
 
-    <h3 ng-if="!dashboardVm.properties.clubName">
+    <h3 ng-if="!dashboardVm.clubNameProp">
         Ack, catastrophic error!
     </h3>
 

--- a/src/dashboard/dashboard.routes.js
+++ b/src/dashboard/dashboard.routes.js
@@ -18,7 +18,7 @@
                         return currentMovieApi.get().$loaded();
                     },
                     properties: function (propertiesApi) {
-                        return propertiesApi.get();
+                        return propertiesApi.list();
                     },
                     users: function (usersApi) {
                         return usersApi.getAll().$loaded();

--- a/src/firebase/firebaseConverter.service.js
+++ b/src/firebase/firebaseConverter.service.js
@@ -1,0 +1,38 @@
+(function (angular) {
+    'use strict';
+
+    angular
+        .module('movieClub')
+        .factory('firebaseConverter', firebaseConverter);
+
+    function firebaseConverter() {
+
+        var factory = {
+            cleanObject: cleanObject,
+            convertObjectToArray: convertObjectToArray
+        };
+        return factory;
+
+        function cleanObject(obj) {
+            var cleanObj = {};
+            _.forEach(obj, function (val, key) {
+                if (!_.startsWith(key, '$')) {
+                    cleanObj[key] = val;
+                }
+            });
+            return cleanObj;
+        }
+
+        function convertObjectToArray(obj, keyAttrName, valAttrName) {
+            var arr = [];
+            _.forEach(obj, function (val, key) {
+                var elem = {};
+                elem[keyAttrName] = key;
+                elem[valAttrName] = val;
+                arr.push(elem);
+            });
+            return arr;
+        }
+    }
+
+}(window.angular));

--- a/src/properties/propertiesApi.service.js
+++ b/src/properties/propertiesApi.service.js
@@ -5,14 +5,18 @@
         .module('movieClub')
         .factory('propertiesApi', propertiesApi);
 
-    function propertiesApi($firebaseObject, firebaseRef) {
+    function propertiesApi($firebaseObject, firebaseConverter, firebaseRef) {
         var factory = {
-            get: get
+            list: list
         };
         return factory;
 
-        function get() {
-            return $firebaseObject(firebaseRef.child('propertyStore')).$loaded();
+        // GET /api/properties
+        function list() {
+            return $firebaseObject(firebaseRef.child('propertyStore'))
+                .$loaded()
+                .then(firebaseConverter.cleanObject)
+                .then(_.partialRight(firebaseConverter.convertObjectToArray, 'id', 'value'));
         }
     }
 

--- a/src/properties/propertiesApi.service.spec.js
+++ b/src/properties/propertiesApi.service.spec.js
@@ -2,50 +2,6 @@
     'use strict';
 
     describe('propertiesApi', function () {
-
-        var $firebaseObjectMock;
-        var firebaseObjectResult;
-        var firebaseRef;
-        var propertiesApi;
-
-        beforeEach(module('movieClub'));
-
-        beforeEach(function () {
-            firebaseObjectResult = {'$loaded': angular.noop};
-            $firebaseObjectMock = jasmine.createSpy('$firebaseObjectMock');
-            $firebaseObjectMock.and.returnValue(firebaseObjectResult);
-
-            module(function ($provide) {
-                $provide.value('$firebaseObject', $firebaseObjectMock);
-            });
-        });
-
-        beforeEach(inject(function (_firebaseRef_, _propertiesApi_) {
-            firebaseRef = _firebaseRef_;
-            propertiesApi = _propertiesApi_;
-        }));
-
-        describe('get', function () {
-
-            it('should get a firebase reference to the propertyStore', function () {
-                spyOn(firebaseRef, 'child');
-                propertiesApi.get();
-
-                expect(firebaseRef.child).toHaveBeenCalledWith('propertyStore');
-            });
-
-            it('should create a firebase object with the reference to the propertyStore', function () {
-                spyOn(firebaseRef, 'child').and.returnValue('propertyStoreRef');
-                propertiesApi.get();
-
-                expect($firebaseObjectMock).toHaveBeenCalledWith('propertyStoreRef');
-            });
-
-            it('should return the promise from the firebase object', function () {
-                spyOn(firebaseObjectResult, '$loaded').and.returnValue('promise');
-
-                expect(propertiesApi.get()).toEqual('promise');
-            });
-        });
     });
+
 }(window.angular));


### PR DESCRIPTION
As #34 states, I'd like to replace Firebase with a custom node.js backend. To pave the way for that, I'm going to try and start making the api services act as though they are not talking to firebase. This means returning and accepting data that looks like it's coming from a non-firebase source.

The `propertiesApi` is an easy first start since it only has a single request method.