### PR TITLE
Firebase interface cleanup

### DIFF
--- a/src/firebase/firebaseCleaner.service.js
+++ b/src/firebase/firebaseCleaner.service.js
@@ -1,0 +1,39 @@
+(function (angular) {
+    'use strict';
+
+    angular
+        .module('movieClub')
+        .factory('firebaseCleaner', firebaseCleaner);
+
+    function firebaseCleaner() {
+
+        var factory = {
+            cleanArray: cleanArray,
+            cleanObject: cleanObject
+        };
+        return factory;
+
+        function cleanArray(array) {
+            var cleanArr = [];
+            _.forEach(array, function (obj) {
+                cleanArr.push(cleanObject(obj));
+            });
+            return cleanArr;
+        }
+
+        function cleanObject(obj) {
+            var cleanObj = {};
+            if (obj.$id) {
+                cleanObj.id = obj.$id;
+            }
+            _.forEach(obj, function (val, key) {
+                if (!_.startsWith(key, '$')) {
+                    cleanObj[key] = val;
+                }
+            });
+            return cleanObj;
+        }
+
+    }
+
+}(window.angular));

--- a/src/firebase/firebaseCleaner.service.js
+++ b/src/firebase/firebaseCleaner.service.js
@@ -14,11 +14,9 @@
         return factory;
 
         function cleanArray(array) {
-            var cleanArr = [];
-            _.forEach(array, function (obj) {
-                cleanArr.push(cleanObject(obj));
+            return _.map(array, function (obj) {
+                return cleanObject(obj);
             });
-            return cleanArr;
         }
 
         function cleanObject(obj) {

--- a/src/firebase/firebaseConverter.service.js
+++ b/src/firebase/firebaseConverter.service.js
@@ -1,0 +1,44 @@
+(function (angular) {
+    'use strict';
+
+    angular
+        .module('movieClub')
+        .factory('firebaseConverter', firebaseConverter);
+
+    function firebaseConverter($firebaseObject) {
+
+        var factory = {
+            convertFirebaseArrayToArray: convertFirebaseArrayToArray,
+            convertFirebaseObjectToArray: convertFirebaseObjectToArray,
+            convertFirebaseObjectToObject: convertFirebaseObjectToObject
+        };
+        return factory;
+
+        function convertFirebaseArrayToArray(firebaseArray) {
+            return _.map(firebaseArray, function (firebaseObj) {
+                return convertFirebaseObjectToObject(firebaseObj);
+            });
+        }
+
+        function convertFirebaseObjectToArray(firebaseObj) {
+            var obj = convertFirebaseObjectToObject(firebaseObj);
+            return _.map(obj, function (val, key) {
+                return {id: key, value: val};
+            });
+        }
+
+        function convertFirebaseObjectToObject(firebaseObj) {
+            var obj = {};
+            if (firebaseObj.$id) {
+                obj.id = firebaseObj.$id;
+            }
+            _.forEach(firebaseObj, function (val, key) {
+                if (!_.startsWith(key, '$')) {
+                    obj[key] = val;
+                }
+            });
+            return obj;
+        }
+    }
+
+}(window.angular));

--- a/src/firebase/firebaseInterface.service.js
+++ b/src/firebase/firebaseInterface.service.js
@@ -3,39 +3,16 @@
 
     angular
         .module('movieClub')
-        .factory('firebaseConverter', firebaseConverter);
+        .factory('firebaseInterface', firebaseInterface);
 
-    function firebaseConverter() {
+    function firebaseInterface(firebaseCleaner) {
 
         var factory = {
-            cleanArray: cleanArray,
-            cleanObject: cleanObject,
             convertObjectToArray: convertObjectToArray,
             removeObject: removeObject,
             updateObject: updateObject
         };
         return factory;
-
-        function cleanArray(array) {
-            var cleanArr = [];
-            _.forEach(array, function (obj) {
-                cleanArr.push(cleanObject(obj));
-            });
-            return cleanArr;
-        }
-
-        function cleanObject(obj) {
-            var cleanObj = {};
-            if (obj.$id) {
-                cleanObj.id = obj.$id;
-            }
-            _.forEach(obj, function (val, key) {
-                if (!_.startsWith(key, '$')) {
-                    cleanObj[key] = val;
-                }
-            });
-            return cleanObj;
-        }
 
         function convertObjectToArray(obj, keyAttrName, valAttrName) {
             var arr = [];
@@ -58,7 +35,7 @@
         function updateObject(obj, newData) {
             return _.merge(obj, newData)
                 .$save()
-                .then(factory.cleanObject);
+                .then(firebaseCleaner.cleanObject);
         }
     }
 

--- a/src/properties/propertiesApi.service.js
+++ b/src/properties/propertiesApi.service.js
@@ -5,7 +5,9 @@
         .module('movieClub')
         .factory('propertiesApi', propertiesApi);
 
-    function propertiesApi($firebaseObject, firebaseCleaner, firebaseInterface, firebaseRef) {
+    function propertiesApi(firebaseInterface, firebaseRef) {
+
+        var propertiesRef = firebaseRef.child('propertyStore');
         var factory = {
             list: list
         };
@@ -13,10 +15,7 @@
 
         // GET /api/properties
         function list() {
-            return $firebaseObject(firebaseRef.child('propertyStore'))
-                .$loaded()
-                .then(firebaseCleaner.cleanObject)
-                .then(_.partialRight(firebaseInterface.convertObjectToArray, 'id', 'value'));
+            return firebaseInterface.getObjectAsArray(propertiesRef);
         }
     }
 

--- a/src/properties/propertiesApi.service.js
+++ b/src/properties/propertiesApi.service.js
@@ -5,7 +5,7 @@
         .module('movieClub')
         .factory('propertiesApi', propertiesApi);
 
-    function propertiesApi($firebaseObject, firebaseConverter, firebaseRef) {
+    function propertiesApi($firebaseObject, firebaseCleaner, firebaseInterface, firebaseRef) {
         var factory = {
             list: list
         };
@@ -15,8 +15,8 @@
         function list() {
             return $firebaseObject(firebaseRef.child('propertyStore'))
                 .$loaded()
-                .then(firebaseConverter.cleanObject)
-                .then(_.partialRight(firebaseConverter.convertObjectToArray, 'id', 'value'));
+                .then(firebaseCleaner.cleanObject)
+                .then(_.partialRight(firebaseInterface.convertObjectToArray, 'id', 'value'));
         }
     }
 

--- a/src/users/usersApi.service.js
+++ b/src/users/usersApi.service.js
@@ -5,7 +5,7 @@
         .module('movieClub')
         .factory('usersApi', usersApi);
 
-    function usersApi($firebaseArray, $firebaseObject, firebaseConverter, firebaseRef) {
+    function usersApi($firebaseArray, $firebaseObject, firebaseCleaner, firebaseInterface, firebaseRef) {
         var factory = {
             'delete': del,
             get: get,
@@ -18,28 +18,28 @@
         function del(userId) {
             return $firebaseObject(firebaseRef.child('users').child(userId))
                 .$loaded()
-                .then(firebaseConverter.removeObject);
+                .then(firebaseInterface.removeObject);
         }
 
         // GET /api/users/:userId
         function get(userId) {
             return $firebaseObject(firebaseRef.child('users').child(userId))
                 .$loaded()
-                .then(firebaseConverter.cleanObject);
+                .then(firebaseCleaner.cleanObject);
         }
 
         // GET /api/users
         function list() {
             return $firebaseArray(firebaseRef.child('users'))
                 .$loaded()
-                .then(firebaseConverter.cleanArray);
+                .then(firebaseCleaner.cleanArray);
         }
 
         // PATCH /api/users/:userId
         function update(user) {
             $firebaseObject(firebaseRef.child('users').child(user.id))
                 .$loaded()
-                .then(firebaseConverter.updateObject);
+                .then(firebaseInterface.updateObject);
         }
     }
 

--- a/src/users/usersApi.service.js
+++ b/src/users/usersApi.service.js
@@ -5,7 +5,9 @@
         .module('movieClub')
         .factory('usersApi', usersApi);
 
-    function usersApi($firebaseArray, $firebaseObject, firebaseCleaner, firebaseInterface, firebaseRef) {
+    function usersApi(firebaseInterface, firebaseRef) {
+
+        var usersRef = firebaseRef.child('users');
         var factory = {
             'delete': del,
             get: get,
@@ -16,30 +18,22 @@
 
         // DELETE /api/users/:userId
         function del(userId) {
-            return $firebaseObject(firebaseRef.child('users').child(userId))
-                .$loaded()
-                .then(firebaseInterface.removeObject);
+            return firebaseInterface.deleteObject(usersRef.child(userId));
         }
 
         // GET /api/users/:userId
         function get(userId) {
-            return $firebaseObject(firebaseRef.child('users').child(userId))
-                .$loaded()
-                .then(firebaseCleaner.cleanObject);
+            return firebaseInterface.getObject(usersRef.child(userId));
         }
 
         // GET /api/users
         function list() {
-            return $firebaseArray(firebaseRef.child('users'))
-                .$loaded()
-                .then(firebaseCleaner.cleanArray);
+            return firebaseInterface.getArray(usersRef);
         }
 
         // PATCH /api/users/:userId
         function update(user) {
-            $firebaseObject(firebaseRef.child('users').child(user.id))
-                .$loaded()
-                .then(firebaseInterface.updateObject);
+            return firebaseInterface.updateObject(usersRef.child(user.id), user);
         }
     }
 


### PR DESCRIPTION
This splits logic out of `firebaseConverter` into `firebaseInterface` and pushes more of the boilerplate firebase stuff down into `firebaseInterface`. I'm going to continue pushing all firebase related code behind the `firebaseInterface` in preparation for replacing Firebase with a custom NodeJS backend.