### PR TITLE
Remove unused meetingApi code

### DIFF
--- a/src/hostMeeting/meetingApi.service.js
+++ b/src/hostMeeting/meetingApi.service.js
@@ -8,19 +8,12 @@
     function meetingApi(firebaseRef, $firebaseObject, $firebaseArray) {
         var factory = {
             getAll: getAll,
-            getByDate: getByDate,
             saveMeeting: saveMeeting
         };
         return factory;
 
         function getAll() {
             return $firebaseArray(firebaseRef.child('meetings'));
-        }
-
-        function getByDate(date) {
-            if (date) {
-                return $firebaseObject(firebaseRef.child('meetings').child(formatDate(date)));
-            }
         }
 
         function saveMeeting(date, presentUsers, selectedMovieName, selectedMovieUserId) {

--- a/src/hostMeeting/meetingApi.service.spec.js
+++ b/src/hostMeeting/meetingApi.service.spec.js
@@ -42,25 +42,6 @@
             });
 
         });
-
-        describe('getByDate', function () {
-
-            it('should get a firebase meeting object', function () {
-                var date = new Date();
-                var firebaseRefChildResponse = {
-                    child: function() {
-                        return null;
-                    }
-                };
-                spyOn(firebaseRef, 'child').and.returnValue(firebaseRefChildResponse);
-                spyOn(firebaseRef.child('meetings'), 'child');
-                meetingApi.getByDate(date);
-
-                expect(firebaseRef.child('meetings').child).toHaveBeenCalledWith(formatDate(date));
-            });
-
-        });
-
     });
 
     function formatDate(date) {


### PR DESCRIPTION
The `getByDate` method in `meetingApi` isn't used. This removes it and related tests.