### PR TITLE
Use different format for meetings in firebase

### DIFF
--- a/FIREBASE.md
+++ b/FIREBASE.md
@@ -92,12 +92,16 @@ In general, my strategy is to keep permissions restrictive until a use-case appe
 
     "meetings": {
 
-      ".read": "true",
+      ".read": "root.child('adminStore').child(auth.uid).val() === true",
       ".write": "root.child('adminStore').child(auth.uid).val() === true",
 
-      "$date": {
+      "$meetingId": {
 
-        ".validate": "newData.hasChildren(['presentUsers', 'selectedMovieName', 'selectedMovieUserId'])",
+        ".validate": "newData.hasChildren(['date', 'presentUsers', 'selectedMovieName', 'selectedMovieUserId'])",
+
+        "date": {
+          ".validate": "newData.isString() && newData.val().matches(/^(19|20)[0-9][0-9][-\\/. ](0[1-9]|1[012])[-\\/. ](0[1-9]|[12][0-9]|3[01])$/)"
+        },
 
         "presentUsers": {
           "$userId": {

--- a/src/hostMeeting/meetingApi.service.js
+++ b/src/hostMeeting/meetingApi.service.js
@@ -17,20 +17,24 @@
         }
 
         function saveMeeting(date, presentUsers, selectedMovieName, selectedMovieUserId) {
-            if (date) {
-                var data = {
-                    presentUsers: presentUsers,
-                    selectedMovieName: selectedMovieName,
-                    selectedMovieUserId: selectedMovieUserId
-                };
-                firebaseRef.child('meetings').child(formatDate(date)).set(data);
-            }
+            var data = {
+                date: formatDate(date),
+                presentUsers: presentUsers,
+                selectedMovieName: selectedMovieName,
+                selectedMovieUserId: selectedMovieUserId
+            };
+            firebaseRef.child('meetings').push(data);
         }
 
         function formatDate(date) {
-            return date.getFullYear() + '-' +
-                   (date.getMonth() + 1) + '-' +
-                   date.getDate();
+            var year = date.getFullYear();
+            var month = date.getMonth() + 1;
+            var day = date.getDate();
+
+            month = ('0' + month).slice(-2);
+            day = ('0' + day).slice(-2);
+
+            return year + '-' + month + '-' + day;
         }
     }
 

--- a/src/hostMeeting/meetingApi.service.spec.js
+++ b/src/hostMeeting/meetingApi.service.spec.js
@@ -43,10 +43,4 @@
 
         });
     });
-
-    function formatDate(date) {
-        return date.getFullYear() + '-' +
-               (date.getMonth() + 1) + '-' +
-               date.getDate();
-    }
 }(window.angular));


### PR DESCRIPTION
This PR accomplishes a couple things:
* Prevents non-admin users from accessing meetings data in firebase
* Removes the unused `formatDate` method in `meetingApi.service.spec.js`
* Changes the meetings model to be a "true" firebase array -- with a generated guid as the key -- and stores the date as a property on the meeting. It also makes sure the dates are stored in yyyy-mm-dd format so that they can be sorted if necessary.

In order to (manually) convert existing meetings to this new format, the following function can be used:

```javascript
function change(ref, key, date) {
   ref.child(key).once('value', function (data) {
      var obj = data.val();
      obj.date = date;
      ref.push(obj);
   });
}
```