### PR TITLE
Upgrade lodash to latest version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,6 @@
     "angularfire": "1.1.1",
     "firebase": "2.2.4",
     "font-awesome": "4.3.0",
-    "lodash": "3.9.3"
+    "lodash": "4.12.0"
   }
 }

--- a/src/auth/register.controller.js
+++ b/src/auth/register.controller.js
@@ -11,7 +11,7 @@
         // vars
         vm.isSubmitting = false;
         vm.hasRegistrationFailed = false;
-        vm.usernames = _.pluck(users, 'username');
+        vm.usernames = _.map(users, 'username');
 
         // funcs
         vm.register = register;

--- a/src/dashboard/dashboard.controller.js
+++ b/src/dashboard/dashboard.controller.js
@@ -9,7 +9,7 @@
         var vm = this;
         vm.currentMovie = currentMovie;
         vm.clubNameProp = _.find(properties, {id: 'clubName'});
-        vm.usernames = _.pluck(users, 'username');
+        vm.usernames = _.map(users, 'username');
     }
 
 }(window.angular));


### PR DESCRIPTION
Upgrade lodash to latest version. `_.pluck` is removed, but `_.map` works as a drop-in replacement.