### PR TITLE
Replace jshint and jscs with prettier

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,220 +1,204 @@
-module.exports = function (grunt) {
+module.exports = function(grunt) {
+  var config = require("./project.conf.js");
 
-    var config = require('./project.conf.js');
+  require("load-grunt-tasks")(grunt);
 
-    require('load-grunt-tasks')(grunt);
+  grunt.initConfig({
+    autoprefixer: {
+      options: {
+        browsers: ["last 2 versions"],
+        map: true
+      },
+      all: {
+        src: config.out.cssFile
+      }
+    },
 
-    grunt.initConfig({
-
-        autoprefixer: {
-            options: {
-                browsers: ['last 2 versions'],
-                map: true
-            },
-            all: {
-                src: config.out.cssFile
-            }
+    cacheBust: {
+      all: {
+        options: {
+          baseDir: config.out.dir,
+          assets: ["js/**/*", "css/**/*"],
+          queryString: true
         },
+        src: [config.out.htmlMainFile]
+      }
+    },
 
-        cacheBust: {
-            all: {
-                options: {
-                    baseDir: config.out.dir,
-                    assets: ['js/**/*', 'css/**/*'],
-                    queryString: true
-                },
-                src: [config.out.htmlMainFile]
-            }
-        },
+    clean: {
+      outputDir: [config.out.dir]
+    },
 
-        clean: {
-            outputDir: [config.out.dir]
-        },
+    concat: {
+      internal: {
+        src: config.in.jsAppClientFiles,
+        dest: config.out.jsAppClientFile
+      },
 
-        concat: {
-            internal: {
-                src: config.in.jsAppClientFiles,
-                dest: config.out.jsAppClientFile
-            },
+      external: {
+        src: config.in.jsThirdPartyClientFiles,
+        dest: config.out.jsThirdPartyClientFile
+      }
+    },
 
-            external: {
-                src: config.in.jsThirdPartyClientFiles,
-                dest: config.out.jsThirdPartyClientFile
-            }
-        },
-
-        connect: {
-            server: {
-                options: {
-                    base: config.out.dir,
-                    protocol: config.dev.serverProtocol,
-                    hostname: config.dev.serverHostname,
-                    port: config.dev.serverPort,
-                    open: true,
-                    livereload: config.dev.serverLivereload
-                }
-            }
-        },
-
-        copy: {
-
-            fonts: {
-                files: [{
-                    src: config.in.fontFiles,
-                    dest: config.out.fontDir,
-                    expand: true,
-                    flatten: true
-                }]
-            },
-
-            images: {
-                files: [{
-                    src: config.in.imageFiles,
-                    dest: config.out.imageDir,
-                    expand: true,
-                    flatten: true
-                }]
-            },
-
-            index: {
-                files: [{
-                    src: config.in.htmlMainFile,
-                    dest: config.out.dir,
-                    expand: true,
-                    flatten: true
-                }]
-            }
-        },
-
-        html2js: {
-
-            options: {
-                fileHeaderString: '(function (angular) {\n\'use strict\';\n',
-                fileFooterString: '}(window.angular));'
-            },
-
-            main: {
-                src: config.in.htmlTemplateFiles,
-                dest: config.out.htmlTemplateFile
-            }
-        },
-
-        jscs: {
-            all: [
-                'Gruntfile.js',
-                config.in.jsAppClientFiles,
-                config.in.jsAppTestFiles
-            ],
-            options: {
-                config: '.jscsrc'
-            }
-        },
-
-        jshint: {
-            all: [
-                'Gruntfile.js',
-                config.in.jsAppClientFiles,
-                config.in.jsAppTestFiles
-            ],
-            options: {
-                jshintrc: '.jshintrc'
-            }
-        },
-
-        karma: {
-            unit: {
-                configFile: 'karma.conf.js',
-                singleRun: true
-            }
-        },
-
-        less: {
-            all: {
-                src: config.in.lessMainFile,
-                dest: config.out.cssFile,
-                options: {
-                    compress: true,
-                    sourceMap: true,
-                    outputSourceFiles: true,
-                    sourceMapFilename: config.out.cssMapFile,
-                    sourceMapURL: config.out.cssMapUrl
-                }
-            }
-        },
-
-        ngAnnotate: {
-            internal: {
-                src: config.out.jsAppClientFile,
-                dest: config.out.jsAppClientFile
-            }
-        },
-
-        uglify: {
-            all: {
-                options: {
-                    sourceMap: true
-                },
-                files: [{
-                    expand: true,
-                    cwd: config.out.jsDir,
-                    src: '**/*.js',
-                    dest: config.out.jsDir
-                }]
-            }
-        },
-
-        watch: {
-
-            dist: {
-                files: [
-                    config.out.dir + '/**/*.*',
-                    '!' + config.out.htmlMainFile
-                ],
-                tasks: 'cacheBust',
-                options: {
-                    livereload: config.dev.serverLivereload
-                }
-            },
-
-            images: {
-                files: config.in.imageFiles,
-                tasks: 'copy:images'
-            },
-
-            index: {
-                files: config.in.htmlMainFile,
-                tasks: 'copy:index',
-                options: {
-                    livereload: config.dev.serverLivereload
-                }
-            },
-
-            jsInternal: {
-                files: config.in.jsAppClientFiles
-                    .concat(config.in.jsAppTestFiles),
-                tasks: ['analyze', 'concat:internal', 'ngAnnotate']
-            },
-
-            jsExternal: {
-                files: config.in.jsThirdPartyClientFiles,
-                tasks: ['analyze', 'concat:external']
-            },
-
-            less: {
-                files: config.in.lessFiles,
-                tasks: 'css'
-            },
-
-            templates: {
-                files: config.in.htmlTemplateFiles,
-                tasks: 'html2js'
-            }
+    connect: {
+      server: {
+        options: {
+          base: config.out.dir,
+          protocol: config.dev.serverProtocol,
+          hostname: config.dev.serverHostname,
+          port: config.dev.serverPort,
+          open: true,
+          livereload: config.dev.serverLivereload
         }
-    });
+      }
+    },
 
-    grunt.registerTask('analyze', ['jshint', 'jscs', 'karma:unit']);
-    grunt.registerTask('css', ['less', 'autoprefixer']);
-    grunt.registerTask('compile', ['clean', 'copy', 'concat', 'css', 'html2js', 'analyze', 'ngAnnotate']);
-    grunt.registerTask('package', ['compile', 'uglify']);
-    grunt.registerTask('serve', ['compile', 'cacheBust', 'connect', 'watch']);
+    copy: {
+      fonts: {
+        files: [
+          {
+            src: config.in.fontFiles,
+            dest: config.out.fontDir,
+            expand: true,
+            flatten: true
+          }
+        ]
+      },
+
+      images: {
+        files: [
+          {
+            src: config.in.imageFiles,
+            dest: config.out.imageDir,
+            expand: true,
+            flatten: true
+          }
+        ]
+      },
+
+      index: {
+        files: [
+          {
+            src: config.in.htmlMainFile,
+            dest: config.out.dir,
+            expand: true,
+            flatten: true
+          }
+        ]
+      }
+    },
+
+    html2js: {
+      options: {
+        fileHeaderString: "(function (angular) {\n'use strict';\n",
+        fileFooterString: "}(window.angular));"
+      },
+
+      main: {
+        src: config.in.htmlTemplateFiles,
+        dest: config.out.htmlTemplateFile
+      }
+    },
+
+    karma: {
+      unit: {
+        configFile: "karma.conf.js",
+        singleRun: true
+      }
+    },
+
+    less: {
+      all: {
+        src: config.in.lessMainFile,
+        dest: config.out.cssFile,
+        options: {
+          compress: true,
+          sourceMap: true,
+          outputSourceFiles: true,
+          sourceMapFilename: config.out.cssMapFile,
+          sourceMapURL: config.out.cssMapUrl
+        }
+      }
+    },
+
+    ngAnnotate: {
+      internal: {
+        src: config.out.jsAppClientFile,
+        dest: config.out.jsAppClientFile
+      }
+    },
+
+    uglify: {
+      all: {
+        options: {
+          sourceMap: true
+        },
+        files: [
+          {
+            expand: true,
+            cwd: config.out.jsDir,
+            src: "**/*.js",
+            dest: config.out.jsDir
+          }
+        ]
+      }
+    },
+
+    watch: {
+      dist: {
+        files: [config.out.dir + "/**/*.*", "!" + config.out.htmlMainFile],
+        tasks: "cacheBust",
+        options: {
+          livereload: config.dev.serverLivereload
+        }
+      },
+
+      images: {
+        files: config.in.imageFiles,
+        tasks: "copy:images"
+      },
+
+      index: {
+        files: config.in.htmlMainFile,
+        tasks: "copy:index",
+        options: {
+          livereload: config.dev.serverLivereload
+        }
+      },
+
+      jsInternal: {
+        files: config.in.jsAppClientFiles.concat(config.in.jsAppTestFiles),
+        tasks: ["karma:unit", "concat:internal", "ngAnnotate"]
+      },
+
+      jsExternal: {
+        files: config.in.jsThirdPartyClientFiles,
+        tasks: ["karma:unit", "concat:external"]
+      },
+
+      less: {
+        files: config.in.lessFiles,
+        tasks: "css"
+      },
+
+      templates: {
+        files: config.in.htmlTemplateFiles,
+        tasks: "html2js"
+      }
+    }
+  });
+
+  grunt.registerTask("css", ["less", "autoprefixer"]);
+  grunt.registerTask("compile", [
+    "clean",
+    "copy",
+    "concat",
+    "css",
+    "html2js",
+    "karma:unit",
+    "ngAnnotate"
+  ]);
+  grunt.registerTask("package", ["compile", "uglify"]);
+  grunt.registerTask("serve", ["compile", "cacheBust", "connect", "watch"]);
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,65 +1,52 @@
 // Karma configuration
 // Generated on Mon Apr 20 2015 19:40:51 GMT-0500 (CDT)
 
-var projectConfig = require('./project.conf.js');
+var projectConfig = require("./project.conf.js");
 
 module.exports = function(config) {
   config.set({
-
     // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '',
-
+    basePath: "",
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jasmine'],
-
+    frameworks: ["jasmine"],
 
     // list of files / patterns to load in the browser
     files: projectConfig.in.jsThirdPartyClientFiles
-        .concat(projectConfig.in.jsThirdPartyTestFiles)
-        .concat(projectConfig.out.htmlTemplateFile)
-        .concat(projectConfig.in.jsAppClientFiles)
-        .concat(projectConfig.in.jsAppTestFiles),
+      .concat(projectConfig.in.jsThirdPartyTestFiles)
+      .concat(projectConfig.out.htmlTemplateFile)
+      .concat(projectConfig.in.jsAppClientFiles)
+      .concat(projectConfig.in.jsAppTestFiles),
 
     // list of files to exclude
-    exclude: [
-    ],
-
+    exclude: [],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-    },
-
+    preprocessors: {},
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
-
+    reporters: ["progress"],
 
     // web server port
     port: 9876,
 
-
     // enable / disable colors in the output (reporters and logs)
     colors: true,
-
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
     logLevel: config.LOG_INFO,
 
-
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: true,
 
-
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
-
+    browsers: ["PhantomJS"],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -78,6 +78,12 @@
       "from": "angularfire@2.3.0",
       "resolved": "https://registry.npmjs.org/angularfire/-/angularfire-2.3.0.tgz"
     },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "from": "ansi-escapes@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "from": "ansi-regex@>=2.0.0 <3.0.0",
@@ -94,6 +100,18 @@
       "version": "1.3.0",
       "from": "anymatch@>=1.3.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+      "dev": true
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "from": "app-root-path@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "from": "argparse@>=1.0.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "dev": true
     },
     "arr-diff": {
@@ -157,6 +175,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "dev": true
     },
+    "ast-types": {
+      "version": "0.9.8",
+      "from": "ast-types@0.9.8",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.8.tgz",
+      "dev": true
+    },
     "async": {
       "version": "1.5.2",
       "from": "async@>=1.5.2 <2.0.0",
@@ -185,6 +209,18 @@
       "version": "1.6.0",
       "from": "aws4@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.22.0",
+      "from": "babel-code-frame@6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "dev": true
+    },
+    "babylon": {
+      "version": "7.0.0-beta.8",
+      "from": "babylon@7.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.8.tgz",
       "dev": true
     },
     "backo2": {
@@ -352,6 +388,12 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
       "dev": true
     },
+    "ci-info": {
+      "version": "1.0.0",
+      "from": "ci-info@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
+      "dev": true
+    },
     "clean-css": {
       "version": "3.4.25",
       "from": "clean-css@>=3.4.0 <3.5.0",
@@ -372,10 +414,22 @@
         }
       }
     },
-    "cli": {
-      "version": "1.0.1",
-      "from": "cli@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+    "cli-cursor": {
+      "version": "1.0.2",
+      "from": "cli-cursor@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "dev": true
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "from": "cli-spinners@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "from": "cli-truncate@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "dev": true
     },
     "cliui": {
@@ -390,6 +444,24 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "dev": true,
       "optional": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "from": "color-convert@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "dev": true
+    },
+    "color-name": {
+      "version": "1.1.2",
+      "from": "color-name@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
+      "dev": true
     },
     "colors": {
       "version": "1.1.2",
@@ -471,12 +543,6 @@
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.0.tgz",
       "dev": true
     },
-    "console-browserify": {
-      "version": "1.1.0",
-      "from": "console-browserify@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "dev": true
-    },
     "constant-case": {
       "version": "2.0.0",
       "from": "constant-case@>=2.0.0 <3.0.0",
@@ -519,6 +585,34 @@
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "1.1.0",
+      "from": "cosmiconfig@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "dev": true
+        }
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "from": "cross-spawn@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.0.2",
+          "from": "lru-cache@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+          "dev": true
+        }
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
@@ -573,10 +667,10 @@
         }
       }
     },
-    "date-now": {
-      "version": "0.1.4",
-      "from": "date-now@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+    "date-fns": {
+      "version": "1.28.3",
+      "from": "date-fns@>=1.27.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.28.3.tgz",
       "dev": true
     },
     "debug": {
@@ -629,44 +723,6 @@
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "dev": true
     },
-    "dom-serializer": {
-      "version": "0.1.0",
-      "from": "dom-serializer@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "from": "domelementtype@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "dev": true
-        },
-        "entities": {
-          "version": "1.1.1",
-          "from": "entities@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "dev": true
-        }
-      }
-    },
-    "domelementtype": {
-      "version": "1.3.0",
-      "from": "domelementtype@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "dev": true
-    },
-    "domhandler": {
-      "version": "2.3.0",
-      "from": "domhandler@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "dev": true
-    },
-    "domutils": {
-      "version": "1.5.1",
-      "from": "domutils@>=1.5.0 <1.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "dev": true
-    },
     "dot-case": {
       "version": "2.1.1",
       "from": "dot-case@>=2.1.0 <3.0.0",
@@ -684,6 +740,12 @@
       "version": "1.1.1",
       "from": "ee-first@1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "dev": true
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "from": "elegant-spinner@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "dev": true
     },
     "encodeurl": {
@@ -750,12 +812,6 @@
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "dev": true
     },
-    "entities": {
-      "version": "1.0.0",
-      "from": "entities@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-      "dev": true
-    },
     "errno": {
       "version": "0.1.4",
       "from": "errno@>=0.1.1 <0.2.0",
@@ -787,16 +843,34 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "dev": true
     },
+    "esprima": {
+      "version": "3.1.3",
+      "from": "esprima@>=3.1.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "from": "esutils@2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "dev": true
+    },
     "eventemitter3": {
       "version": "1.2.0",
       "from": "eventemitter3@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
       "dev": true
     },
-    "exit": {
-      "version": "0.1.2",
-      "from": "exit@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+    "execa": {
+      "version": "0.6.3",
+      "from": "execa@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.6.3.tgz",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "from": "exit-hook@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "dev": true
     },
     "expand-braces": {
@@ -927,6 +1001,12 @@
       "version": "1.0.0",
       "from": "finalhandler@1.0.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz",
+      "dev": true
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "from": "find-parent-dir@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
       "dev": true
     },
     "find-up": {
@@ -1134,6 +1214,12 @@
           "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
         }
       }
+    },
+    "flow-parser": {
+      "version": "0.43.0",
+      "from": "flow-parser@0.43.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.43.0.tgz",
+      "dev": true
     },
     "font-awesome": {
       "version": "4.7.0",
@@ -2018,6 +2104,12 @@
       "version": "4.0.1",
       "from": "get-stdin@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "from": "get-stream@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "dev": true
     },
     "getpass": {
@@ -3490,12 +3582,6 @@
         }
       }
     },
-    "grunt-contrib-jshint": {
-      "version": "1.1.0",
-      "from": "grunt-contrib-jshint@1.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
-      "dev": true
-    },
     "grunt-contrib-less": {
       "version": "1.4.1",
       "from": "grunt-contrib-less@1.4.1",
@@ -3828,844 +3914,6 @@
       "resolved": "https://registry.npmjs.org/grunt-html2js/-/grunt-html2js-0.3.8.tgz",
       "dev": true
     },
-    "grunt-jscs": {
-      "version": "3.0.1",
-      "from": "grunt-jscs@3.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-3.0.1.tgz",
-      "dev": true,
-      "dependencies": {
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-          "dev": true
-        },
-        "jscs": {
-          "version": "3.0.7",
-          "from": "jscs@>=3.0.5 <3.1.0",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-3.0.7.tgz",
-          "dev": true,
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dev": true,
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "dev": true
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "dev": true
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "dev": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "dev": true
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "dev": true
-                }
-              }
-            },
-            "cli-table": {
-              "version": "0.3.1",
-              "from": "cli-table@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-              "dev": true,
-              "dependencies": {
-                "colors": {
-                  "version": "1.0.3",
-                  "from": "colors@1.0.3",
-                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                  "dev": true
-                }
-              }
-            },
-            "commander": {
-              "version": "2.9.0",
-              "from": "commander@>=2.9.0 <2.10.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "dev": true,
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                  "dev": true
-                }
-              }
-            },
-            "cst": {
-              "version": "0.4.6",
-              "from": "cst@>=0.4.3 <0.5.0",
-              "resolved": "https://registry.npmjs.org/cst/-/cst-0.4.6.tgz",
-              "dev": true,
-              "dependencies": {
-                "babel-runtime": {
-                  "version": "6.18.0",
-                  "from": "babel-runtime@>=6.9.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "core-js": {
-                      "version": "2.4.1",
-                      "from": "core-js@>=2.4.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-                      "dev": true
-                    },
-                    "regenerator-runtime": {
-                      "version": "0.9.5",
-                      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz",
-                      "dev": true
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.13.1",
-                  "from": "babylon@>=6.8.1 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.13.1.tgz",
-                  "dev": true
-                },
-                "source-map-support": {
-                  "version": "0.4.6",
-                  "from": "source-map-support@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "source-map": {
-                      "version": "0.5.6",
-                      "from": "source-map@>=0.5.3 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "from": "estraverse@>=4.1.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-              "dev": true
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-              "dev": true
-            },
-            "glob": {
-              "version": "5.0.15",
-              "from": "glob@>=5.0.1 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "dev": true,
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.6",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "dev": true
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "dev": true
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "dev": true
-                }
-              }
-            },
-            "htmlparser2": {
-              "version": "3.8.3",
-              "from": "htmlparser2@3.8.3",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-              "dev": true,
-              "dependencies": {
-                "domelementtype": {
-                  "version": "1.3.0",
-                  "from": "domelementtype@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-                  "dev": true
-                },
-                "domhandler": {
-                  "version": "2.3.0",
-                  "from": "domhandler@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-                  "dev": true
-                },
-                "domutils": {
-                  "version": "1.5.1",
-                  "from": "domutils@>=1.5.0 <1.6.0",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "dom-serializer": {
-                      "version": "0.1.0",
-                      "from": "dom-serializer@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                      "dev": true,
-                      "dependencies": {
-                        "domelementtype": {
-                          "version": "1.1.3",
-                          "from": "domelementtype@>=1.1.1 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                          "dev": true
-                        },
-                        "entities": {
-                          "version": "1.1.1",
-                          "from": "entities@>=1.1.1 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.0.0",
-                  "from": "entities@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-                  "dev": true
-                },
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "dev": true
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "js-yaml": {
-              "version": "3.4.6",
-              "from": "js-yaml@>=3.4.0 <3.5.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-              "dev": true,
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.9",
-                  "from": "argparse@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                      "dev": true
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.3",
-                  "from": "esprima@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                  "dev": true
-                },
-                "inherit": {
-                  "version": "2.2.6",
-                  "from": "inherit@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.6.tgz",
-                  "dev": true
-                }
-              }
-            },
-            "jscs-jsdoc": {
-              "version": "2.0.0",
-              "from": "jscs-jsdoc@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-2.0.0.tgz",
-              "dev": true,
-              "dependencies": {
-                "comment-parser": {
-                  "version": "0.3.1",
-                  "from": "comment-parser@>=0.3.1 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.3.1.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.1.5",
-                      "from": "readable-stream@>=2.0.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                      "dev": true,
-                      "dependencies": {
-                        "buffer-shims": {
-                          "version": "1.0.0",
-                          "from": "buffer-shims@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                          "dev": true
-                        },
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "dev": true
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "dev": true
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "from": "isarray@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "dev": true
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "dev": true
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "dev": true
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "jsdoctypeparser": {
-                  "version": "1.2.0",
-                  "from": "jsdoctypeparser@>=1.2.0 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz",
-                  "dev": true
-                }
-              }
-            },
-            "jscs-preset-wikimedia": {
-              "version": "1.0.0",
-              "from": "jscs-preset-wikimedia@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.0.tgz",
-              "dev": true
-            },
-            "jsonlint": {
-              "version": "1.6.2",
-              "from": "jsonlint@>=1.6.2 <1.7.0",
-              "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.2.tgz",
-              "dev": true,
-              "dependencies": {
-                "JSV": {
-                  "version": "4.0.2",
-                  "from": "JSV@>=4.0.0",
-                  "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-                  "dev": true
-                },
-                "nomnom": {
-                  "version": "1.8.1",
-                  "from": "nomnom@>=1.5.0",
-                  "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "chalk": {
-                      "version": "0.4.0",
-                      "from": "chalk@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                      "dev": true,
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "1.0.0",
-                          "from": "ansi-styles@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-                          "dev": true
-                        },
-                        "has-color": {
-                          "version": "0.1.7",
-                          "from": "has-color@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-                          "dev": true
-                        },
-                        "strip-ansi": {
-                          "version": "0.1.1",
-                          "from": "strip-ansi@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "underscore": {
-                      "version": "1.6.0",
-                      "from": "underscore@>=1.6.0 <1.7.0",
-                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "from": "lodash@>=3.10.0 <3.11.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "dev": true
-            },
-            "minimatch": {
-              "version": "3.0.3",
-              "from": "minimatch@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "dev": true,
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.6",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "balanced-match@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "natural-compare": {
-              "version": "1.2.2",
-              "from": "natural-compare@>=1.2.2 <1.3.0",
-              "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.2.2.tgz",
-              "dev": true
-            },
-            "pathval": {
-              "version": "0.1.1",
-              "from": "pathval@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
-              "dev": true
-            },
-            "prompt": {
-              "version": "0.2.14",
-              "from": "prompt@>=0.2.14 <0.3.0",
-              "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
-              "dev": true,
-              "dependencies": {
-                "pkginfo": {
-                  "version": "0.4.0",
-                  "from": "pkginfo@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
-                  "dev": true
-                },
-                "read": {
-                  "version": "1.0.7",
-                  "from": "read@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "mute-stream": {
-                      "version": "0.0.6",
-                      "from": "mute-stream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-                      "dev": true
-                    }
-                  }
-                },
-                "revalidator": {
-                  "version": "0.1.8",
-                  "from": "revalidator@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
-                  "dev": true
-                },
-                "utile": {
-                  "version": "0.2.1",
-                  "from": "utile@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "async": {
-                      "version": "0.2.10",
-                      "from": "async@>=0.2.9 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                      "dev": true
-                    },
-                    "deep-equal": {
-                      "version": "1.0.1",
-                      "from": "deep-equal@*",
-                      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-                      "dev": true
-                    },
-                    "i": {
-                      "version": "0.3.5",
-                      "from": "i@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
-                      "dev": true
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dev": true,
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "ncp": {
-                      "version": "0.4.2",
-                      "from": "ncp@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-                      "dev": true
-                    },
-                    "rimraf": {
-                      "version": "2.5.4",
-                      "from": "rimraf@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                      "dev": true,
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.1.1",
-                          "from": "glob@>=7.0.5 <8.0.0",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                          "dev": true,
-                          "dependencies": {
-                            "fs.realpath": {
-                              "version": "1.0.0",
-                              "from": "fs.realpath@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                              "dev": true
-                            },
-                            "inflight": {
-                              "version": "1.0.6",
-                              "from": "inflight@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                              "dev": true,
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.2",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.3",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                              "dev": true
-                            },
-                            "once": {
-                              "version": "1.4.0",
-                              "from": "once@>=1.3.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                              "dev": true,
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.2",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.1",
-                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "winston": {
-                  "version": "0.8.3",
-                  "from": "winston@>=0.8.0 <0.9.0",
-                  "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "async": {
-                      "version": "0.2.10",
-                      "from": "async@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                      "dev": true
-                    },
-                    "colors": {
-                      "version": "0.6.2",
-                      "from": "colors@>=0.6.0 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-                      "dev": true
-                    },
-                    "cycle": {
-                      "version": "1.0.3",
-                      "from": "cycle@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-                      "dev": true
-                    },
-                    "eyes": {
-                      "version": "0.1.8",
-                      "from": "eyes@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-                      "dev": true
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                      "dev": true
-                    },
-                    "pkginfo": {
-                      "version": "0.3.1",
-                      "from": "pkginfo@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-                      "dev": true
-                    },
-                    "stack-trace": {
-                      "version": "0.0.9",
-                      "from": "stack-trace@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "reserved-words": {
-              "version": "0.1.1",
-              "from": "reserved-words@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.1.tgz",
-              "dev": true
-            },
-            "resolve": {
-              "version": "1.1.7",
-              "from": "resolve@>=1.1.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-              "dev": true
-            },
-            "strip-bom": {
-              "version": "2.0.0",
-              "from": "strip-bom@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "dev": true,
-              "dependencies": {
-                "is-utf8": {
-                  "version": "0.2.1",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                  "dev": true
-                }
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-              "dev": true
-            },
-            "to-double-quotes": {
-              "version": "2.0.0",
-              "from": "to-double-quotes@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
-              "dev": true
-            },
-            "to-single-quotes": {
-              "version": "2.0.1",
-              "from": "to-single-quotes@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.1.tgz",
-              "dev": true
-            },
-            "vow-fs": {
-              "version": "0.3.6",
-              "from": "vow-fs@>=0.3.4 <0.4.0",
-              "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.6.tgz",
-              "dev": true,
-              "dependencies": {
-                "glob": {
-                  "version": "7.1.1",
-                  "from": "glob@>=7.0.5 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                  "dev": true,
-                  "dependencies": {
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                      "dev": true
-                    },
-                    "inflight": {
-                      "version": "1.0.6",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                      "dev": true,
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "dev": true
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "dev": true,
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                      "dev": true
-                    }
-                  }
-                },
-                "uuid": {
-                  "version": "2.0.3",
-                  "from": "uuid@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-                  "dev": true
-                },
-                "vow-queue": {
-                  "version": "0.4.2",
-                  "from": "vow-queue@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz",
-                  "dev": true
-                }
-              }
-            },
-            "xmlbuilder": {
-              "version": "3.1.0",
-              "from": "xmlbuilder@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.6.1",
-          "from": "lodash@>=4.6.1 <4.7.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz",
-          "dev": true
-        },
-        "vow": {
-          "version": "0.4.13",
-          "from": "vow@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.13.tgz",
-          "dev": true
-        }
-      }
-    },
     "grunt-karma": {
       "version": "2.0.0",
       "from": "grunt-karma@2.0.0",
@@ -4754,12 +4002,6 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "dev": true
     },
-    "hooker": {
-      "version": "0.2.3",
-      "from": "hooker@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-      "dev": true
-    },
     "hosted-git-info": {
       "version": "2.4.2",
       "from": "hosted-git-info@>=2.1.4 <3.0.0",
@@ -4786,12 +4028,6 @@
         }
       }
     },
-    "htmlparser2": {
-      "version": "3.8.3",
-      "from": "htmlparser2@>=3.8.0 <3.9.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-      "dev": true
-    },
     "http-errors": {
       "version": "1.6.1",
       "from": "http-errors@>=1.6.1 <1.7.0",
@@ -4809,6 +4045,20 @@
       "from": "http-signature@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "dev": true
+    },
+    "husky": {
+      "version": "0.13.3",
+      "from": "husky@latest",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.13.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "from": "normalize-path@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "dev": true
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.15",
@@ -4871,6 +4121,12 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "dev": true
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "from": "is-ci@>=1.0.9 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.2",
       "from": "is-dotfile@>=1.0.0 <2.0.0",
@@ -4899,6 +4155,12 @@
       "version": "1.0.2",
       "from": "is-finite@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "dev": true
     },
     "is-glob": {
@@ -4941,8 +4203,7 @@
       "version": "2.1.0",
       "from": "is-promise@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-property": {
       "version": "1.0.2",
@@ -5034,6 +4295,18 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.2.tgz",
       "dev": true
     },
+    "jest-matcher-utils": {
+      "version": "19.0.0",
+      "from": "jest-matcher-utils@>=19.0.0 <20.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-19.0.0.tgz",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "19.0.0",
+      "from": "jest-validate@19.0.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-19.0.0.tgz",
+      "dev": true
+    },
     "jodid25519": {
       "version": "1.0.2",
       "from": "jodid25519@>=1.0.0 <2.0.0",
@@ -5041,26 +4314,24 @@
       "dev": true,
       "optional": true
     },
+    "js-tokens": {
+      "version": "3.0.1",
+      "from": "js-tokens@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.8.3",
+      "from": "js-yaml@>=3.4.3 <4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.3.tgz",
+      "dev": true
+    },
     "jsbn": {
       "version": "0.1.1",
       "from": "jsbn@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "dev": true,
       "optional": true
-    },
-    "jshint": {
-      "version": "2.9.4",
-      "from": "jshint@>=2.9.4 <2.10.0",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
-      "dev": true,
-      "dependencies": {
-        "lodash": {
-          "version": "3.7.0",
-          "from": "lodash@>=3.7.0 <3.8.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
-          "dev": true
-        }
-      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -5205,6 +4476,50 @@
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
       "dev": true
     },
+    "leven": {
+      "version": "2.1.0",
+      "from": "leven@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "dev": true
+    },
+    "lint-staged": {
+      "version": "3.4.0",
+      "from": "lint-staged@latest",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-3.4.0.tgz",
+      "dev": true
+    },
+    "listr": {
+      "version": "0.11.0",
+      "from": "listr@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.11.0.tgz",
+      "dev": true
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "from": "listr-silent-renderer@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.2.0",
+      "from": "listr-update-renderer@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "indent-string": {
+          "version": "3.1.0",
+          "from": "indent-string@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.1.0.tgz",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.0",
+      "from": "listr-verbose-renderer@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz",
+      "dev": true
+    },
     "load-grunt-tasks": {
       "version": "3.5.2",
       "from": "load-grunt-tasks@3.5.2",
@@ -5340,6 +4655,18 @@
       "version": "4.5.0",
       "from": "lodash.clonedeep@>=4.5.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "1.0.2",
+      "from": "log-symbols@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "dev": true
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "from": "log-update@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
       "dev": true
     },
     "log4js": {
@@ -5524,6 +4851,24 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "dev": true
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "from": "npm-path@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "from": "npm-run-path@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "dev": true
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "from": "npm-which@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "dev": true
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
@@ -5578,6 +4923,12 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "dev": true
     },
+    "onetime": {
+      "version": "1.1.0",
+      "from": "onetime@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "dev": true
+    },
     "optimist": {
       "version": "0.3.7",
       "from": "optimist@>=0.3.5 <0.4.0",
@@ -5589,6 +4940,12 @@
       "version": "0.0.6",
       "from": "options@>=0.0.5",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "dev": true
+    },
+    "ora": {
+      "version": "0.2.3",
+      "from": "ora@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "dev": true
     },
     "ordered-ast-traverse": {
@@ -5603,10 +4960,22 @@
       "resolved": "https://registry.npmjs.org/ordered-esprima-props/-/ordered-esprima-props-1.1.0.tgz",
       "dev": true
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "from": "os-homedir@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "dev": true
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "from": "os-tmpdir@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "from": "p-finally@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "dev": true
     },
     "pako": {
@@ -5679,6 +5048,12 @@
       "version": "1.0.1",
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "from": "path-key@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "dev": true
     },
     "path-type": {
@@ -5768,11 +5143,45 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "dev": true
     },
+    "prettier": {
+      "version": "1.2.2",
+      "from": "prettier@latest",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.2.2.tgz",
+      "dev": true,
+      "dependencies": {
+        "get-stdin": {
+          "version": "5.0.1",
+          "from": "get-stdin@5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "dev": true
+        }
+      }
+    },
     "pretty-bytes": {
       "version": "1.0.4",
       "from": "pretty-bytes@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "19.0.0",
+      "from": "pretty-format@>=19.0.0 <20.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.0.0",
+          "from": "ansi-styles@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.0.0.tgz",
+          "dev": true
+        }
+      }
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -5799,6 +5208,12 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "dev": true,
       "optional": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "from": "pseudomap@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
@@ -5846,12 +5261,6 @@
       "version": "1.0.1",
       "from": "read-pkg-up@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "dev": true
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "from": "readable-stream@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "dev": true
     },
     "readdirp": {
@@ -5935,10 +5344,22 @@
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "dev": true
     },
+    "require-from-string": {
+      "version": "1.2.1",
+      "from": "require-from-string@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "dev": true
+    },
     "requires-port": {
       "version": "1.0.0",
       "from": "requires-port@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "from": "restore-cursor@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "dev": true
     },
     "right-align": {
@@ -5951,6 +5372,12 @@
       "version": "2.6.1",
       "from": "rimraf@>=2.2.8 <3.0.0",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "5.3.0",
+      "from": "rxjs@>=5.0.0-beta.11 <6.0.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.3.0.tgz",
       "dev": true
     },
     "safe-buffer": {
@@ -5983,10 +5410,16 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.3.0",
-      "from": "shelljs@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+    "shebang-command": {
+      "version": "1.2.0",
+      "from": "shebang-command@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "dev": true
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "dev": true
     },
     "signal-exit": {
@@ -6005,6 +5438,12 @@
       "version": "0.2.0",
       "from": "simple-is@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "from": "slice-ansi@0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "dev": true
     },
     "snake-case": {
@@ -6135,6 +5574,12 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "dev": true
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "from": "sprintf-js@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "dev": true
+    },
     "sshpk": {
       "version": "1.13.0",
       "from": "sshpk@>=1.7.0 <2.0.0",
@@ -6155,16 +5600,34 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "from": "staged-git-files@0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "dev": true
+    },
     "statuses": {
       "version": "1.3.1",
       "from": "statuses@>=1.3.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "dev": true
     },
+    "stream-to-observable": {
+      "version": "0.1.0",
+      "from": "stream-to-observable@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
+      "dev": true
+    },
     "string_decoder": {
       "version": "0.10.31",
       "from": "string_decoder@>=0.10.0 <0.11.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "from": "string-width@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "dev": true
     },
     "stringmap": {
@@ -6197,16 +5660,16 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "dev": true
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "from": "strip-eof@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "dev": true
+    },
     "strip-indent": {
       "version": "1.0.1",
       "from": "strip-indent@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "dev": true
-    },
-    "strip-json-comments": {
-      "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "dev": true
     },
     "supports-color": {
@@ -6219,6 +5682,12 @@
       "version": "1.1.2",
       "from": "swap-case@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "dev": true
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "from": "symbol-observable@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
       "dev": true
     },
     "throttleit": {
@@ -6478,6 +5947,12 @@
       "version": "4.0.1",
       "from": "xtend@>=4.0.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "from": "yallist@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,14 @@
     "url": "https://github.com/charwking/movie-club/issues"
   },
   "scripts": {
-    "test": "grunt package"
+    "test": "grunt package",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "homepage": "https://github.com/charwking/movie-club",
   "devDependencies": {
@@ -24,20 +31,21 @@
     "grunt-contrib-concat": "1.0.1",
     "grunt-contrib-connect": "1.0.2",
     "grunt-contrib-copy": "1.0.0",
-    "grunt-contrib-jshint": "1.1.0",
     "grunt-contrib-less": "1.4.1",
     "grunt-contrib-uglify": "2.3.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-html2js": "0.3.8",
-    "grunt-jscs": "3.0.1",
     "grunt-karma": "2.0.0",
     "grunt-ng-annotate": "3.0.0",
+    "husky": "0.13.3",
     "jasmine-core": "2.5.2",
     "karma": "1.6.0",
     "karma-jasmine": "1.1.0",
     "karma-phantomjs-launcher": "1.0.4",
+    "lint-staged": "3.4.0",
     "load-grunt-tasks": "3.5.2",
-    "phantomjs-prebuilt": "2.1.14"
+    "phantomjs-prebuilt": "2.1.14",
+    "prettier": "1.2.2"
   },
   "dependencies": {
     "angular": "1.6.4",

--- a/project.conf.js
+++ b/project.conf.js
@@ -1,61 +1,58 @@
 var dirs = {
-    output: 'dist/',
-    source: 'src/',
-    test: 'test/',
-    npm: 'node_modules/',
-    lib: 'lib/'
+  output: "dist/",
+  source: "src/",
+  test: "test/",
+  npm: "node_modules/",
+  lib: "lib/"
 };
 
 module.exports = {
+  out: {
+    dir: dirs.output,
+    cssFile: dirs.output + "css/app.css",
+    cssMapFile: dirs.output + "css/app.css.map",
+    cssMapUrl: "css/app.css.map",
+    fontDir: dirs.output + "/fonts",
+    htmlMainFile: dirs.output + "index.html",
+    htmlTemplateFile: dirs.output + "js/templates.js",
+    imageDir: dirs.output + "/images",
+    jsDir: dirs.output + "js/",
+    jsAppClientFile: dirs.output + "js/internal.js",
+    jsThirdPartyClientFile: dirs.output + "js/external.js"
+  },
 
-    out: {
-        dir: dirs.output,
-        cssFile: dirs.output + 'css/app.css',
-        cssMapFile: dirs.output + 'css/app.css.map',
-        cssMapUrl: 'css/app.css.map',
-        fontDir: dirs.output + '/fonts',
-        htmlMainFile: dirs.output + 'index.html',
-        htmlTemplateFile: dirs.output + 'js/templates.js',
-        imageDir: dirs.output + '/images',
-        jsDir: dirs.output + 'js/',
-        jsAppClientFile: dirs.output + 'js/internal.js',
-        jsThirdPartyClientFile: dirs.output + 'js/external.js'
-    },
+  in: {
+    dir: dirs.source,
+    fontFiles: dirs.npm + "font-awesome/fonts/**/*",
+    htmlMainFile: dirs.source + "index.html",
+    htmlTemplateFiles: [
+      dirs.source + "**/*.html",
+      "!" + dirs.source + "index.html"
+    ],
+    imageFiles: dirs.source + "images/**/*",
+    jsAppClientFiles: [
+      dirs.source + "app.js",
+      dirs.source + "**/*.js",
+      "!" + dirs.source + "**/*.spec.js"
+    ],
+    jsAppTestFiles: dirs.source + "**/*.spec.js",
+    jsThirdPartyClientFiles: [
+      dirs.npm + "angular/angular.js",
+      dirs.npm + "angular-ui-router/release/angular-ui-router.js",
+      dirs.npm + "angular-google-analytics/dist/angular-google-analytics.js",
+      dirs.npm + "firebase/firebase.js",
+      dirs.npm + "angularfire/dist/angularfire.js",
+      dirs.npm + "lodash/lodash.js"
+    ],
+    jsThirdPartyTestFiles: [dirs.npm + "angular-mocks/angular-mocks.js"],
+    lessFiles: dirs.source + "/**/*.less",
+    lessMainFile: dirs.source + "styles/app.less"
+  },
 
-    in: {
-        dir: dirs.source,
-        fontFiles: dirs.npm + 'font-awesome/fonts/**/*',
-        htmlMainFile: dirs.source + 'index.html',
-        htmlTemplateFiles: [
-            dirs.source + '**/*.html',
-            '!' + dirs.source + 'index.html'
-        ],
-        imageFiles: dirs.source + 'images/**/*',
-        jsAppClientFiles: [
-            dirs.source + 'app.js',
-            dirs.source + '**/*.js',
-            '!' + dirs.source + '**/*.spec.js'
-        ],
-        jsAppTestFiles: dirs.source + '**/*.spec.js',
-        jsThirdPartyClientFiles: [
-            dirs.npm + 'angular/angular.js',
-            dirs.npm + 'angular-ui-router/release/angular-ui-router.js',
-            dirs.npm + 'angular-google-analytics/dist/angular-google-analytics.js',
-            dirs.npm + 'firebase/firebase.js',
-            dirs.npm + 'angularfire/dist/angularfire.js',
-            dirs.npm + 'lodash/lodash.js'
-        ],
-        jsThirdPartyTestFiles: [
-            dirs.npm + 'angular-mocks/angular-mocks.js'
-        ],
-        lessFiles: dirs.source + '/**/*.less',
-        lessMainFile: dirs.source + 'styles/app.less'
-    },
-
-    dev: {
-        serverProtocol: 'http',
-        serverHostname: 'localhost',
-        serverPort: 8000,
-        serverLivereload: true
-    }
+  dev: {
+    serverProtocol: "http",
+    serverHostname: "localhost",
+    serverPort: 8000,
+    serverLivereload: true
+  }
 };

--- a/src/admin/admin.routes.js
+++ b/src/admin/admin.routes.js
@@ -1,23 +1,17 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").config(appConfig);
 
-    angular
-        .module('movieClub')
-        .config(appConfig);
-
-    /* @ngInject */
-    function appConfig($stateProvider) {
-
-        $stateProvider
-            .state('admin', {
-                abstract: true,
-                template: '<ui-view/>',
-                resolve: {
-                    currentAuth: function ($firebaseAuthService) {
-                        return $firebaseAuthService.requireSignInAsAdmin();
-                    }
-                }
-            });
-    }
-
-}());
+  /* @ngInject */
+  function appConfig($stateProvider) {
+    $stateProvider.state("admin", {
+      abstract: true,
+      template: "<ui-view/>",
+      resolve: {
+        currentAuth: function($firebaseAuthService) {
+          return $firebaseAuthService.requireSignInAsAdmin();
+        }
+      }
+    });
+  }
+})();

--- a/src/admin/hostMeeting/hostMeeting.controller.js
+++ b/src/admin/hostMeeting/hostMeeting.controller.js
@@ -1,136 +1,141 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  angular
+    .module("movieClub")
+    .controller("HostMeetingController", HostMeetingController);
 
-    angular
-        .module('movieClub')
-        .controller('HostMeetingController', HostMeetingController);
+  function HostMeetingController(
+    $state,
+    currentMovie,
+    currentMovieUser,
+    meetings,
+    movieSelector,
+    movieQueueFactory,
+    users,
+    userMovies
+  ) {
+    var presentUsers = {};
+    var userCredits = {};
+    var totalCredits = 0;
 
-    function HostMeetingController(
-        $state, currentMovie, currentMovieUser, meetings, movieSelector, movieQueueFactory, users, userMovies) {
+    var vm = this;
+    vm.allUsers = users;
 
-        var presentUsers = {};
-        var userCredits = {};
-        var totalCredits = 0;
+    vm.anyUserHasMovies = anyUserHasMovies;
+    vm.userHasMovies = userHasMovies;
+    vm.userIsPresent = userIsPresent;
+    vm.makeUserPresent = makeUserPresent;
+    vm.makeUserAbsent = makeUserAbsent;
+    vm.getUserOdds = getUserOdds;
+    vm.selectMovie = selectMovie;
 
-        var vm = this;
-        vm.allUsers = users;
-
-        vm.anyUserHasMovies = anyUserHasMovies;
-        vm.userHasMovies = userHasMovies;
-        vm.userIsPresent = userIsPresent;
-        vm.makeUserPresent = makeUserPresent;
-        vm.makeUserAbsent = makeUserAbsent;
-        vm.getUserOdds = getUserOdds;
-        vm.selectMovie = selectMovie;
-
-        function userHasMovies(user) {
-            var movies = _.find(userMovies, {'$id': user.$id});
-            return movies && _.keys(movies).length > 0;
-        }
-
-        function anyUserHasMovies() {
-            return _.some(vm.allUsers, function (user) {
-                return userIsPresent(user) && userHasMovies(user);
-            });
-        }
-
-        function userIsPresent(user) {
-            return (user.$id in presentUsers);
-        }
-
-        function makeUserPresent(user) {
-            presentUsers[user.$id] = true;
-            if (userHasMovies(user)) {
-                userCredits[user.$id] =
-                    movieSelector.calculateUserAttendanceCredit(meetings, user.$id);
-                totalCredits += userCredits[user.$id];
-            }
-        }
-
-        function makeUserAbsent(user) {
-            delete presentUsers[user.$id];
-            if (userCredits[user.$id]) {
-                totalCredits -= userCredits[user.$id];
-                delete userCredits[user.$id];
-            }
-        }
-
-        function getUserOdds(user) {
-            if (user.$id in userCredits) {
-                return (totalCredits === 0) ?
-                    100 * 1 / _.keys(userCredits).length :
-                    100 * userCredits[user.$id] / totalCredits;
-            } else {
-                return 0;
-            }
-        }
-
-        function selectWinner() {
-            var n = 0;
-            var ranges = _.reduce(vm.allUsers, function (ranges, user) {
-                var odds = getUserOdds(user);
-                if (odds !== 0) {
-                    ranges = ranges.concat({min: n, max: n + odds, userId: user.$id});
-                    n += odds;
-                }
-                return ranges;
-            }, []);
-            n = _.random(0, 100, true);
-            return _.find(ranges, function (range) {
-                return range.min <= n && n < range.max;
-            }).userId;
-        }
-
-        function selectMovie() {
-            var userId = selectWinner();
-            var movies = userMovies.$getRecord(userId).movies;
-            var pick = _(movies).sortBy('order').first();
-
-            currentMovie.name = pick.name;
-            currentMovie.trailerUrl = pick.trailerUrl || null;
-            currentMovie.$save();
-            currentMovieUser.userId = userId;
-            currentMovieUser.$save();
-
-            movieQueueFactory
-                .getForUserId(userId)
-                .$loaded()
-                .then(function (movies) {
-                    var movie = _.find(movies, {order: pick.order});
-                    return movies.$remove(movie).then(function () {
-                        _(movies)
-                            .sortBy('order')
-                            .forEach(function (movie, index) {
-                                movie.order = index;
-                                movies.$save(movie);
-                            });
-                    });
-                });
-
-            saveMeeting();
-            $state.go('dashboard');
-        }
-
-        function saveMeeting() {
-
-            function formatDate(date) {
-                var year = date.getFullYear();
-                var month = date.getMonth() + 1;
-                var day = date.getDate();
-
-                month = ('0' + month).slice(-2);
-                day = ('0' + day).slice(-2);
-
-                return year + '-' + month + '-' + day;
-            }
-
-            meetings.$add({
-                date: formatDate(new Date()),
-                presentUsers: presentUsers,
-                selectedMovieName: currentMovie.name,
-                selectedMovieUserId: currentMovieUser.userId
-            });
-        }
+    function userHasMovies(user) {
+      var movies = _.find(userMovies, { $id: user.$id });
+      return movies && _.keys(movies).length > 0;
     }
 
-}(window.angular));
+    function anyUserHasMovies() {
+      return _.some(vm.allUsers, function(user) {
+        return userIsPresent(user) && userHasMovies(user);
+      });
+    }
+
+    function userIsPresent(user) {
+      return user.$id in presentUsers;
+    }
+
+    function makeUserPresent(user) {
+      presentUsers[user.$id] = true;
+      if (userHasMovies(user)) {
+        userCredits[user.$id] = movieSelector.calculateUserAttendanceCredit(
+          meetings,
+          user.$id
+        );
+        totalCredits += userCredits[user.$id];
+      }
+    }
+
+    function makeUserAbsent(user) {
+      delete presentUsers[user.$id];
+      if (userCredits[user.$id]) {
+        totalCredits -= userCredits[user.$id];
+        delete userCredits[user.$id];
+      }
+    }
+
+    function getUserOdds(user) {
+      if (user.$id in userCredits) {
+        return totalCredits === 0
+          ? 100 * 1 / _.keys(userCredits).length
+          : 100 * userCredits[user.$id] / totalCredits;
+      } else {
+        return 0;
+      }
+    }
+
+    function selectWinner() {
+      var n = 0;
+      var ranges = _.reduce(
+        vm.allUsers,
+        function(ranges, user) {
+          var odds = getUserOdds(user);
+          if (odds !== 0) {
+            ranges = ranges.concat({ min: n, max: n + odds, userId: user.$id });
+            n += odds;
+          }
+          return ranges;
+        },
+        []
+      );
+      n = _.random(0, 100, true);
+      return _.find(ranges, function(range) {
+        return range.min <= n && n < range.max;
+      }).userId;
+    }
+
+    function selectMovie() {
+      var userId = selectWinner();
+      var movies = userMovies.$getRecord(userId).movies;
+      var pick = _(movies).sortBy("order").first();
+
+      currentMovie.name = pick.name;
+      currentMovie.trailerUrl = pick.trailerUrl || null;
+      currentMovie.$save();
+      currentMovieUser.userId = userId;
+      currentMovieUser.$save();
+
+      movieQueueFactory.getForUserId(userId).$loaded().then(function(movies) {
+        var movie = _.find(movies, { order: pick.order });
+        return movies.$remove(movie).then(function() {
+          _(movies).sortBy("order").forEach(function(movie, index) {
+            movie.order = index;
+            movies.$save(movie);
+          });
+        });
+      });
+
+      saveMeeting();
+      $state.go("dashboard");
+    }
+
+    function saveMeeting() {
+      function formatDate(date) {
+        var year = date.getFullYear();
+        var month = date.getMonth() + 1;
+        var day = date.getDate();
+
+        month = ("0" + month).slice(-2);
+        day = ("0" + day).slice(-2);
+
+        return year + "-" + month + "-" + day;
+      }
+
+      meetings.$add({
+        date: formatDate(new Date()),
+        presentUsers: presentUsers,
+        selectedMovieName: currentMovie.name,
+        selectedMovieUserId: currentMovieUser.userId
+      });
+    }
+  }
+})(window.angular);

--- a/src/admin/hostMeeting/hostMeeting.routes.js
+++ b/src/admin/hostMeeting/hostMeeting.routes.js
@@ -1,18 +1,12 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").config(appConfig);
 
-    angular
-        .module('movieClub')
-        .config(appConfig);
-
-    function appConfig($stateProvider) {
-
-        $stateProvider
-            .state('admin.hostMeeting', {
-                controller: 'HostMeetingController as hostMeetingVm',
-                templateUrl: 'admin/hostMeeting/hostMeeting.html',
-                url: '/admin/host-meeting'
-            });
-    }
-
-}());
+  function appConfig($stateProvider) {
+    $stateProvider.state("admin.hostMeeting", {
+      controller: "HostMeetingController as hostMeetingVm",
+      templateUrl: "admin/hostMeeting/hostMeeting.html",
+      url: "/admin/host-meeting"
+    });
+  }
+})();

--- a/src/admin/hostMeeting/movieSelector.service.js
+++ b/src/admin/hostMeeting/movieSelector.service.js
@@ -1,47 +1,44 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").factory("movieSelector", movieSelector);
 
-    angular
-        .module('movieClub')
-        .factory('movieSelector', movieSelector);
+  function movieSelector() {
+    var factory = {
+      calculateUserAttendanceCredit: calculateUserAttendanceCredit
+    };
 
-    function movieSelector() {
-        var factory = {
-            calculateUserAttendanceCredit: calculateUserAttendanceCredit
-        };
+    return factory;
 
-        return factory;
+    function calculateUserAttendanceCredit(meetings, userId) {
+      // everyone gets credit for today if it's the first meeting
+      if (meetings.length === 0) {
+        return 1;
+      }
 
-        function calculateUserAttendanceCredit(meetings, userId) {
+      meetings = _.sortBy(meetings, "date");
 
-            // everyone gets credit for today if it's the first meeting
-            if (meetings.length === 0) {
-                return 1;
-            }
+      // No user gets two movies in a row
+      if (meetings[meetings.length - 1].selectedMovieUserId === userId) {
+        return 0;
+      }
 
-            meetings = _.sortBy(meetings, 'date');
+      // trim the meetings to only those this user attended
+      meetings = _.filter(meetings, function(meeting) {
+        return meeting.presentUsers[userId];
+      });
 
-            // No user gets two movies in a row
-            if (meetings[meetings.length - 1].selectedMovieUserId === userId) {
-                return 0;
-            }
+      var picks = _.filter(meetings, { selectedMovieUserId: userId });
 
-            // trim the meetings to only those this user attended
-            meetings = _.filter(meetings, function (meeting) {
-                return meeting.presentUsers[userId];
-            });
+      // Get credit for all your meetings if you've never had your movie picked
+      if (picks.length === 0) {
+        return meetings.length + 1;
+      }
 
-            var picks = _.filter(meetings, {selectedMovieUserId: userId});
-
-            // Get credit for all your meetings if you've never had your movie picked
-            if (picks.length === 0) {
-                return meetings.length + 1;
-            }
-
-            // Get credit for every attendance since your last pick (including today)
-            var lastPickIndex = _.findIndex(meetings, {date: picks[picks.length - 1].date});
-            return meetings.length - lastPickIndex;
-        }
+      // Get credit for every attendance since your last pick (including today)
+      var lastPickIndex = _.findIndex(meetings, {
+        date: picks[picks.length - 1].date
+      });
+      return meetings.length - lastPickIndex;
     }
-
-}());
+  }
+})();

--- a/src/admin/hostMeeting/movieSelector.service.spec.js
+++ b/src/admin/hostMeeting/movieSelector.service.spec.js
@@ -1,112 +1,126 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  describe("movieSelector", function() {
+    var subject;
 
-    describe('movieSelector', function () {
-
-        var subject;
-
-        beforeEach(function () {
-            module('movieClub');
-            inject(function (movieSelector) {
-                subject = movieSelector;
-            });
-        });
-
-        describe('calculateUserAttendanceCredit', function () {
-
-            it('returns 1 if there have never been any meetings', function () {
-                var count = subject.calculateUserAttendanceCredit([], '1');
-                expect(count).toEqual(1);
-            });
-
-            it('returns 1 if the user has never attended', function () {
-                var meetings = [{
-                        date: '2015-12-10',
-                        selectedMovieUserId: '1',
-                        presentUsers: {'1': true, '2': true}
-                    }, {
-                        date: '2016-01-10',
-                        selectedMovieUserId: '2',
-                        presentUsers: {'1': true, '2': true}
-                    }];
-
-                var count = subject.calculateUserAttendanceCredit(meetings, '3');
-
-                expect(count).toEqual(1);
-            });
-
-            it('returns 0 if the last movie picked was from this user', function () {
-                var meetings = [{
-                        date: '2015-01-01',
-                        selectedMovieUserId: '1',
-                        presentUsers: {'1': true, '2': true}
-                    }, {
-                        date: '2015-01-08',
-                        selectedMovieUserId: '2',
-                        presentUsers: {'1': true, '2': true}
-                    }];
-
-                var count = subject.calculateUserAttendanceCredit(meetings, '2');
-
-                expect(count).toEqual(0);
-            });
-
-            it('returns 1 if this is the first attendance since their movie was picked', function () {
-                var meetings = [{
-                        date: '2015-01-01',
-                        selectedMovieUserId: '1',
-                        presentUsers: {'1': true, '2': true}
-                    }, {
-                        date: '2015-01-08',
-                        selectedMovieUserId: '2',
-                        presentUsers: {'1': true, '2': true}
-                    }, {
-                        date: '2015-01-15',
-                        selectedMovieUserId: '1',
-                        presentUsers: {'1': true, '3': true}
-                    }, {
-                        date: '2015-01-22',
-                        selectedMovieUserId: '3',
-                        presentUsers: {'1': true, '3': true}
-                    }];
-
-                var count = subject.calculateUserAttendanceCredit(meetings, '2');
-
-                expect(count).toEqual(1);
-            });
-
-            it('returns the number of attendances (including today) since the users movie was picked', function () {
-                var meetings = [{
-                        date: '2015-01-01',
-                        selectedMovieUserId: '1',
-                        presentUsers: {'1': true, '2': true, '3': true}
-                    }, {
-                        date: '2015-01-08',
-                        selectedMovieUserId: '2',
-                        presentUsers: {'1': true, '2': true, '3': true}
-                    }, {
-                        date: '2015-01-15',
-                        selectedMovieUserId: '1',
-                        presentUsers: {'1': true, '3': true, '4': true}
-                    }, {
-                        date: '2015-01-22',
-                        selectedMovieUserId: '3',
-                        presentUsers: {'1': true, '3': true}
-                    }, {
-                        date: '2015-01-29',
-                        selectedMovieUserId: '4',
-                        presentUsers: {'1': true, '2': true, '3': true, '4': true}
-                    }];
-
-                var count = subject.calculateUserAttendanceCredit(meetings, '1');
-                expect(count).toEqual(3);
-
-                count = subject.calculateUserAttendanceCredit(meetings, '2');
-                expect(count).toEqual(2);
-
-                count = subject.calculateUserAttendanceCredit(meetings, '3');
-                expect(count).toEqual(2);
-            });
-        });
+    beforeEach(function() {
+      module("movieClub");
+      inject(function(movieSelector) {
+        subject = movieSelector;
+      });
     });
-}());
+
+    describe("calculateUserAttendanceCredit", function() {
+      it("returns 1 if there have never been any meetings", function() {
+        var count = subject.calculateUserAttendanceCredit([], "1");
+        expect(count).toEqual(1);
+      });
+
+      it("returns 1 if the user has never attended", function() {
+        var meetings = [
+          {
+            date: "2015-12-10",
+            selectedMovieUserId: "1",
+            presentUsers: { "1": true, "2": true }
+          },
+          {
+            date: "2016-01-10",
+            selectedMovieUserId: "2",
+            presentUsers: { "1": true, "2": true }
+          }
+        ];
+
+        var count = subject.calculateUserAttendanceCredit(meetings, "3");
+
+        expect(count).toEqual(1);
+      });
+
+      it("returns 0 if the last movie picked was from this user", function() {
+        var meetings = [
+          {
+            date: "2015-01-01",
+            selectedMovieUserId: "1",
+            presentUsers: { "1": true, "2": true }
+          },
+          {
+            date: "2015-01-08",
+            selectedMovieUserId: "2",
+            presentUsers: { "1": true, "2": true }
+          }
+        ];
+
+        var count = subject.calculateUserAttendanceCredit(meetings, "2");
+
+        expect(count).toEqual(0);
+      });
+
+      it("returns 1 if this is the first attendance since their movie was picked", function() {
+        var meetings = [
+          {
+            date: "2015-01-01",
+            selectedMovieUserId: "1",
+            presentUsers: { "1": true, "2": true }
+          },
+          {
+            date: "2015-01-08",
+            selectedMovieUserId: "2",
+            presentUsers: { "1": true, "2": true }
+          },
+          {
+            date: "2015-01-15",
+            selectedMovieUserId: "1",
+            presentUsers: { "1": true, "3": true }
+          },
+          {
+            date: "2015-01-22",
+            selectedMovieUserId: "3",
+            presentUsers: { "1": true, "3": true }
+          }
+        ];
+
+        var count = subject.calculateUserAttendanceCredit(meetings, "2");
+
+        expect(count).toEqual(1);
+      });
+
+      it("returns the number of attendances (including today) since the users movie was picked", function() {
+        var meetings = [
+          {
+            date: "2015-01-01",
+            selectedMovieUserId: "1",
+            presentUsers: { "1": true, "2": true, "3": true }
+          },
+          {
+            date: "2015-01-08",
+            selectedMovieUserId: "2",
+            presentUsers: { "1": true, "2": true, "3": true }
+          },
+          {
+            date: "2015-01-15",
+            selectedMovieUserId: "1",
+            presentUsers: { "1": true, "3": true, "4": true }
+          },
+          {
+            date: "2015-01-22",
+            selectedMovieUserId: "3",
+            presentUsers: { "1": true, "3": true }
+          },
+          {
+            date: "2015-01-29",
+            selectedMovieUserId: "4",
+            presentUsers: { "1": true, "2": true, "3": true, "4": true }
+          }
+        ];
+
+        var count = subject.calculateUserAttendanceCredit(meetings, "1");
+        expect(count).toEqual(3);
+
+        count = subject.calculateUserAttendanceCredit(meetings, "2");
+        expect(count).toEqual(2);
+
+        count = subject.calculateUserAttendanceCredit(meetings, "3");
+        expect(count).toEqual(2);
+      });
+    });
+  });
+})();

--- a/src/admin/userManagement/userManagement.controller.js
+++ b/src/admin/userManagement/userManagement.controller.js
@@ -1,14 +1,11 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  angular
+    .module("movieClub")
+    .controller("UserManagementController", UserManagementController);
 
-    angular
-        .module('movieClub')
-        .controller('UserManagementController', UserManagementController);
-
-    function UserManagementController(users) {
-        var vm = this;
-        vm.users = users;
-    }
-
-}(window.angular));
-
+  function UserManagementController(users) {
+    var vm = this;
+    vm.users = users;
+  }
+})(window.angular);

--- a/src/admin/userManagement/userManagement.controller.spec.js
+++ b/src/admin/userManagement/userManagement.controller.spec.js
@@ -1,26 +1,21 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  describe("UserManagementController", function() {
+    var subject;
 
-    describe('UserManagementController', function () {
-
-        var subject;
-
-        beforeEach(function () {
-            module('movieClub');
-            inject(function ($controller) {
-                subject = $controller('UserManagementController', {
-                    users: 'users value'
-                });
-            });
+    beforeEach(function() {
+      module("movieClub");
+      inject(function($controller) {
+        subject = $controller("UserManagementController", {
+          users: "users value"
         });
-
-        describe('after initialization', function () {
-
-            it('should expose the users', function () {
-                expect(subject.users).toEqual('users value');
-            });
-        });
+      });
     });
 
-}(window.angular));
-
+    describe("after initialization", function() {
+      it("should expose the users", function() {
+        expect(subject.users).toEqual("users value");
+      });
+    });
+  });
+})(window.angular);

--- a/src/admin/userManagement/userManagement.routes.js
+++ b/src/admin/userManagement/userManagement.routes.js
@@ -1,18 +1,12 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").config(appConfig);
 
-    angular
-        .module('movieClub')
-        .config(appConfig);
-
-    function appConfig($stateProvider) {
-
-        $stateProvider
-            .state('admin.userManagement', {
-                controller: 'UserManagementController as userManagementVm',
-                templateUrl: 'admin/userManagement/userManagement.html',
-                url: '/admin/user-management'
-            });
-    }
-
-}());
+  function appConfig($stateProvider) {
+    $stateProvider.state("admin.userManagement", {
+      controller: "UserManagementController as userManagementVm",
+      templateUrl: "admin/userManagement/userManagement.html",
+      url: "/admin/user-management"
+    });
+  }
+})();

--- a/src/app.js
+++ b/src/app.js
@@ -1,98 +1,100 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  var moduleDependencies = [
+    "angular-google-analytics",
+    "firebase",
+    "templates-main",
+    "ui.router"
+  ];
 
-    var moduleDependencies = [
-        'angular-google-analytics',
-        'firebase',
-        'templates-main',
-        'ui.router'
-    ];
+  angular
+    .module("movieClub", moduleDependencies)
+    .config(setDefaultRoute)
+    .config(configureAnalytics)
+    .config(whitelistTemplateSources)
+    .config(configureFirebase)
+    .run(injectAnalytics)
+    .run(handleAuthStates);
 
-    angular
-        .module('movieClub', moduleDependencies)
-        .config(setDefaultRoute)
-        .config(configureAnalytics)
-        .config(whitelistTemplateSources)
-        .config(configureFirebase)
-        .run(injectAnalytics)
-        .run(handleAuthStates);
+  /* @ngInject */
+  function setDefaultRoute($urlRouterProvider) {
+    $urlRouterProvider.when("", "/");
+    $urlRouterProvider.otherwise("/");
+  }
 
-    /* @ngInject */
-    function setDefaultRoute($urlRouterProvider) {
-        $urlRouterProvider.when('', '/');
-        $urlRouterProvider.otherwise('/');
+  /* @ngInject */
+  function configureAnalytics(AnalyticsProvider) {
+    AnalyticsProvider.setAccount("UA-52798669-1");
+    AnalyticsProvider.trackPages(true);
+    AnalyticsProvider.trackUrlParams(true);
+    AnalyticsProvider.trackPrefix("movie-club");
+  }
+
+  /* @ngInject */
+  function whitelistTemplateSources($sceDelegateProvider) {
+    $sceDelegateProvider.resourceUrlWhitelist([
+      "self",
+      "*://www.youtube.com/**"
+    ]);
+  }
+
+  /* @ngInject */
+  function configureFirebase($firebaseRefProvider) {
+    var location = window.location.href;
+    var isDev =
+      location.match(/^http(s)?:\/\/localhost/) ||
+      location.match(/^http(s)?:\/\/dev\./);
+    var config = isDev ? getDevFirebaseConfig() : getProdFirebaseConfig();
+
+    // HACK -- Calling initializeApp twice for the same app results in an exception,
+    // and this happens during testing since the firebase library isn't completely
+    // reloaded for each test. To circumvent that, we're only initalizing the app
+    // if one doesn't exist -- which we know because app throws an error when no app
+    // exists.
+    try {
+      firebase.app();
+    } catch (e) {
+      firebase.initializeApp(config);
     }
+    $firebaseRefProvider.registerUrl(config.databaseURL);
+  }
 
-    /* @ngInject */
-    function configureAnalytics(AnalyticsProvider) {
-        AnalyticsProvider.setAccount('UA-52798669-1');
-        AnalyticsProvider.trackPages(true);
-        AnalyticsProvider.trackUrlParams(true);
-        AnalyticsProvider.trackPrefix('movie-club');
-    }
+  /* @ngInject */
+  function injectAnalytics(Analytics) {
+    // Analytics injected to enable automatic page tracking
+  }
 
-    /* @ngInject */
-    function whitelistTemplateSources($sceDelegateProvider) {
-        $sceDelegateProvider.resourceUrlWhitelist([
-            'self',
-            '*://www.youtube.com/**'
-        ]);
-    }
+  /* @ngInject */
+  function handleAuthStates($rootScope, $state, authApi) {
+    $rootScope.$on("$stateChangeError", function(
+      event,
+      toState,
+      toParams,
+      fromState,
+      fromParams,
+      error
+    ) {
+      if (error === "AUTH_REQUIRED") {
+        $state.go("login");
+      }
+    });
+  }
 
-    /* @ngInject */
-    function configureFirebase($firebaseRefProvider) {
+  function getDevFirebaseConfig() {
+    return {
+      apiKey: "AIzaSyB12FILGlMqlxgvLtZ29VaP0x5WEOLZT8M",
+      authDomain: "glowing-inferno-1828.firebaseapp.com",
+      databaseURL: "https://glowing-inferno-1828.firebaseio.com",
+      storageBucket: "glowing-inferno-1828.appspot.com"
+    };
+  }
 
-        var location = window.location.href;
-        var isDev =
-            location.match(/^http(s)?:\/\/localhost/) ||
-            location.match(/^http(s)?:\/\/dev\./);
-        var config = isDev ? getDevFirebaseConfig() : getProdFirebaseConfig();
-
-        // HACK -- Calling initializeApp twice for the same app results in an exception,
-        // and this happens during testing since the firebase library isn't completely
-        // reloaded for each test. To circumvent that, we're only initalizing the app
-        // if one doesn't exist -- which we know because app throws an error when no app
-        // exists.
-        try {
-            firebase.app();
-        } catch (e) {
-            firebase.initializeApp(config);
-        }
-        $firebaseRefProvider.registerUrl(config.databaseURL);
-    }
-
-    /* @ngInject */
-    function injectAnalytics(Analytics) {
-        // Analytics injected to enable automatic page tracking
-    }
-
-    /* @ngInject */
-    function handleAuthStates($rootScope, $state, authApi) {
-        $rootScope.$on('$stateChangeError',
-            function (event, toState, toParams, fromState, fromParams, error) {
-                if (error === 'AUTH_REQUIRED') {
-                    $state.go('login');
-                }
-            }
-        );
-    }
-
-    function getDevFirebaseConfig() {
-        return {
-            apiKey: 'AIzaSyB12FILGlMqlxgvLtZ29VaP0x5WEOLZT8M',
-            authDomain: 'glowing-inferno-1828.firebaseapp.com',
-            databaseURL: 'https://glowing-inferno-1828.firebaseio.com',
-            storageBucket: 'glowing-inferno-1828.appspot.com'
-        };
-    }
-
-    function getProdFirebaseConfig() {
-        return {
-            apiKey: 'AIzaSyAKfG5L2MyJ_iJu_DN7WQL30M6v7Or6-2E',
-            authDomain: 'movie-club.firebaseapp.com',
-            databaseURL: 'https://movie-club.firebaseio.com',
-            storageBucket: ''
-        };
-    }
-
-}());
+  function getProdFirebaseConfig() {
+    return {
+      apiKey: "AIzaSyAKfG5L2MyJ_iJu_DN7WQL30M6v7Or6-2E",
+      authDomain: "movie-club.firebaseapp.com",
+      databaseURL: "https://movie-club.firebaseio.com",
+      storageBucket: ""
+    };
+  }
+})();

--- a/src/app.spec.js
+++ b/src/app.spec.js
@@ -1,86 +1,85 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  describe("app", function() {
+    describe("$urlRouterProvider", function() {
+      var $urlRouterProvider;
 
-    describe('app', function () {
-
-        describe('$urlRouterProvider', function () {
-
-            var $urlRouterProvider;
-
-            beforeEach(function () {
-                module('ui.router', function (_$urlRouterProvider_) {
-                    $urlRouterProvider = _$urlRouterProvider_;
-                    spyOn($urlRouterProvider, 'when').and.callThrough();
-                    spyOn($urlRouterProvider, 'otherwise').and.callThrough();
-                });
-                module('movieClub');
-                inject();
-            });
-
-            it('should be configured to use the default route when there is none', function () {
-                expect($urlRouterProvider.when).toHaveBeenCalledWith('', '/');
-            });
-
-            it('should be configured to send all non-matched routes to the default route', function () {
-                expect($urlRouterProvider.otherwise).toHaveBeenCalledWith('/');
-            });
+      beforeEach(function() {
+        module("ui.router", function(_$urlRouterProvider_) {
+          $urlRouterProvider = _$urlRouterProvider_;
+          spyOn($urlRouterProvider, "when").and.callThrough();
+          spyOn($urlRouterProvider, "otherwise").and.callThrough();
         });
+        module("movieClub");
+        inject();
+      });
 
-        describe('AnalyticsProvider', function () {
+      it("should be configured to use the default route when there is none", function() {
+        expect($urlRouterProvider.when).toHaveBeenCalledWith("", "/");
+      });
 
-            var analyticsProvider;
-
-            beforeEach(function () {
-                module('angular-google-analytics', function (_AnalyticsProvider_) {
-                    analyticsProvider = _AnalyticsProvider_;
-                    spyOn(analyticsProvider, 'setAccount').and.callThrough();
-                    spyOn(analyticsProvider, 'trackPages').and.callThrough();
-                    spyOn(analyticsProvider, 'trackUrlParams').and.callThrough();
-                    spyOn(analyticsProvider, 'trackPrefix').and.callThrough();
-                });
-                module('movieClub');
-                inject();
-            });
-
-            it('should be configured with the correct analytics account', function () {
-                expect(analyticsProvider.setAccount).toHaveBeenCalledWith('UA-52798669-1');
-            });
-
-            it('should be configured to track pages', function () {
-                expect(analyticsProvider.trackPages).toHaveBeenCalledWith(true);
-            });
-
-            it('should be configured to track url params', function () {
-                expect(analyticsProvider.trackUrlParams).toHaveBeenCalledWith(true);
-            });
-
-            it('should be configured to use the movie-club prefix', function () {
-                expect(analyticsProvider.trackPrefix).toHaveBeenCalledWith('movie-club');
-            });
-        });
-
-        describe('$sceDelegateProvider', function () {
-
-            var $sceDelegateProvider;
-
-            beforeEach(function () {
-                module('ng', function (_$sceDelegateProvider_) {
-                    $sceDelegateProvider = _$sceDelegateProvider_;
-                    spyOn($sceDelegateProvider, 'resourceUrlWhitelist').and.callThrough();
-                });
-                module('movieClub');
-                inject();
-            });
-
-            it('should be configured to whitelist calls from the current domain', function () {
-                var lastCall = $sceDelegateProvider.resourceUrlWhitelist.calls.mostRecent();
-                expect(lastCall.args[0]).toContain('self');
-            });
-
-            it('should be configured to whitelist youtube URLs', function () {
-                var lastCall = $sceDelegateProvider.resourceUrlWhitelist.calls.mostRecent();
-                expect(lastCall.args[0]).toContain('*://www.youtube.com/**');
-            });
-        });
+      it("should be configured to send all non-matched routes to the default route", function() {
+        expect($urlRouterProvider.otherwise).toHaveBeenCalledWith("/");
+      });
     });
-}());
+
+    describe("AnalyticsProvider", function() {
+      var analyticsProvider;
+
+      beforeEach(function() {
+        module("angular-google-analytics", function(_AnalyticsProvider_) {
+          analyticsProvider = _AnalyticsProvider_;
+          spyOn(analyticsProvider, "setAccount").and.callThrough();
+          spyOn(analyticsProvider, "trackPages").and.callThrough();
+          spyOn(analyticsProvider, "trackUrlParams").and.callThrough();
+          spyOn(analyticsProvider, "trackPrefix").and.callThrough();
+        });
+        module("movieClub");
+        inject();
+      });
+
+      it("should be configured with the correct analytics account", function() {
+        expect(analyticsProvider.setAccount).toHaveBeenCalledWith(
+          "UA-52798669-1"
+        );
+      });
+
+      it("should be configured to track pages", function() {
+        expect(analyticsProvider.trackPages).toHaveBeenCalledWith(true);
+      });
+
+      it("should be configured to track url params", function() {
+        expect(analyticsProvider.trackUrlParams).toHaveBeenCalledWith(true);
+      });
+
+      it("should be configured to use the movie-club prefix", function() {
+        expect(analyticsProvider.trackPrefix).toHaveBeenCalledWith(
+          "movie-club"
+        );
+      });
+    });
+
+    describe("$sceDelegateProvider", function() {
+      var $sceDelegateProvider;
+
+      beforeEach(function() {
+        module("ng", function(_$sceDelegateProvider_) {
+          $sceDelegateProvider = _$sceDelegateProvider_;
+          spyOn($sceDelegateProvider, "resourceUrlWhitelist").and.callThrough();
+        });
+        module("movieClub");
+        inject();
+      });
+
+      it("should be configured to whitelist calls from the current domain", function() {
+        var lastCall = $sceDelegateProvider.resourceUrlWhitelist.calls.mostRecent();
+        expect(lastCall.args[0]).toContain("self");
+      });
+
+      it("should be configured to whitelist youtube URLs", function() {
+        var lastCall = $sceDelegateProvider.resourceUrlWhitelist.calls.mostRecent();
+        expect(lastCall.args[0]).toContain("*://www.youtube.com/**");
+      });
+    });
+  });
+})();

--- a/src/auth/auth.routes.js
+++ b/src/auth/auth.routes.js
@@ -1,28 +1,23 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").config(appConfig);
 
-    angular
-        .module('movieClub')
-        .config(appConfig);
-
-    function appConfig($stateProvider) {
-
-        $stateProvider
-            .state('login', {
-                controller: 'LoginController as loginVm',
-                templateUrl: 'auth/login.html',
-                url: '/auth/login'
-            })
-            .state('register', {
-                controller: 'RegisterController as registerVm',
-                templateUrl: 'auth/register.html',
-                url: '/auth/register'
-            })
-            .state('logout', {
-                controller: 'LogoutController as logoutVm',
-                templateUrl: 'auth/logout.html',
-                url: '/auth/logout'
-            });
-    }
-
-}());
+  function appConfig($stateProvider) {
+    $stateProvider
+      .state("login", {
+        controller: "LoginController as loginVm",
+        templateUrl: "auth/login.html",
+        url: "/auth/login"
+      })
+      .state("register", {
+        controller: "RegisterController as registerVm",
+        templateUrl: "auth/register.html",
+        url: "/auth/register"
+      })
+      .state("logout", {
+        controller: "LogoutController as logoutVm",
+        templateUrl: "auth/logout.html",
+        url: "/auth/logout"
+      });
+  }
+})();

--- a/src/auth/authApi.service.js
+++ b/src/auth/authApi.service.js
@@ -1,41 +1,34 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").factory("authApi", authApi);
 
-    angular
-        .module('movieClub')
-        .factory('authApi', authApi);
+  function authApi($firebaseAuthService, userFactory) {
+    return {
+      login: login,
+      logout: logout,
+      register: register
+    };
 
-    function authApi($firebaseAuthService, userFactory) {
-        return {
-            login: login,
-            logout: logout,
-            register: register
-        };
-
-        function login(email, password) {
-            return $firebaseAuthService
-                .$signInWithEmailAndPassword(email, password);
-        }
-
-        function logout() {
-            $firebaseAuthService.$signOut();
-        }
-
-        function register(username, email, password) {
-            return $firebaseAuthService
-                .$createUserWithEmailAndPassword(email, password)
-                .then(_.partial(login, email, password))
-                .then(_.partial(addUsername, username));
-        }
-
-        function addUsername(username) {
-            return userFactory
-                .get()
-                .$loaded()
-                .then(function (user) {
-                    user.username = username;
-                    return user.$save();
-                });
-        }
+    function login(email, password) {
+      return $firebaseAuthService.$signInWithEmailAndPassword(email, password);
     }
-}());
+
+    function logout() {
+      $firebaseAuthService.$signOut();
+    }
+
+    function register(username, email, password) {
+      return $firebaseAuthService
+        .$createUserWithEmailAndPassword(email, password)
+        .then(_.partial(login, email, password))
+        .then(_.partial(addUsername, username));
+    }
+
+    function addUsername(username) {
+      return userFactory.get().$loaded().then(function(user) {
+        user.username = username;
+        return user.$save();
+      });
+    }
+  }
+})();

--- a/src/auth/authState.service.js
+++ b/src/auth/authState.service.js
@@ -1,29 +1,25 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").factory("authState", authState);
 
-    angular
-        .module('movieClub')
-        .factory('authState', authState);
+  /* @ngInject */
+  function authState($firebaseAuthService, adminStore) {
+    var user;
+    $firebaseAuthService.$onAuthStateChanged(function(newUser) {
+      user = newUser;
+    });
 
-    /* @ngInject */
-    function authState($firebaseAuthService, adminStore) {
+    return {
+      isAdmin: isAdmin,
+      isLoggedIn: isLoggedIn
+    };
 
-        var user;
-        $firebaseAuthService.$onAuthStateChanged(function (newUser) {
-            user = newUser;
-        });
-
-        return {
-            isAdmin: isAdmin,
-            isLoggedIn: isLoggedIn,
-        };
-
-        function isAdmin() {
-            return isLoggedIn() && adminStore[user.uid];
-        }
-
-        function isLoggedIn() {
-            return user && user.uid;
-        }
+    function isAdmin() {
+      return isLoggedIn() && adminStore[user.uid];
     }
-}());
+
+    function isLoggedIn() {
+      return user && user.uid;
+    }
+  }
+})();

--- a/src/auth/authState.service.spec.js
+++ b/src/auth/authState.service.spec.js
@@ -1,86 +1,84 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  describe("authState", function() {
+    var adminStoreMock;
+    var authStateChangedCallback;
+    var subject;
 
-    describe('authState', function () {
+    beforeEach(function() {
+      adminStoreMock = {};
 
-        var adminStoreMock;
-        var authStateChangedCallback;
-        var subject;
+      module("movieClub");
+      module(function($provide) {
+        $provide.value("adminStore", adminStoreMock);
+      });
 
-        beforeEach(function () {
-
-            adminStoreMock = {};
-
-            module('movieClub');
-            module(function ($provide) {
-                $provide.value('adminStore', adminStoreMock);
-            });
-
-            inject(function ($firebaseAuthService) {
-                spyOn($firebaseAuthService, '$onAuthStateChanged').and.callFake(function (cb) {
-                    authStateChangedCallback = cb;
-                });
-            });
-
-            inject(function (authState, _$firebaseAuthService_) {
-                subject = authState;
-            });
+      inject(function($firebaseAuthService) {
+        spyOn(
+          $firebaseAuthService,
+          "$onAuthStateChanged"
+        ).and.callFake(function(cb) {
+          authStateChangedCallback = cb;
         });
+      });
 
-        describe('isLoggedIn', function () {
-
-            it('returns false before the auth state has changed', function () {
-                expect(subject.isLoggedIn()).toBeFalsy();
-            });
-
-            it('returns false if the user is present without an id', function () {
-                authStateChangedCallback({});
-                expect(subject.isLoggedIn()).toBeFalsy();
-            });
-
-            it('returns false if the user is present with a null id', function () {
-                authStateChangedCallback({uid: null});
-                expect(subject.isLoggedIn()).toBeFalsy();
-            });
-
-            it('returns true if the user is present with an id', function () {
-                authStateChangedCallback({uid: 123});
-                expect(subject.isLoggedIn()).toBeTruthy();
-            });
-        });
-
-        describe('isAdmin', function () {
-
-            it('returns false before the auth state has changed', function () {
-                expect(subject.isAdmin()).toBeFalsy();
-            });
-
-            it('returns false if the user is present without an id', function () {
-                authStateChangedCallback({});
-                expect(subject.isAdmin()).toBeFalsy();
-            });
-
-            it('returns false if the user is present with a null id', function () {
-                authStateChangedCallback({uid: null});
-                expect(subject.isAdmin()).toBeFalsy();
-            });
-
-            it('returns false if the user is set but not present in the adminStore', function () {
-                authStateChangedCallback({uid: 123});
-                expect(subject.isAdmin()).toBeFalsy();
-            });
-
-            it('returns false if the user is set and is present in the adminStore with a false flag', function () {
-                authStateChangedCallback({uid: 123});
-                adminStoreMock[123] = false;
-                expect(subject.isAdmin()).toBeFalsy();
-            });
-
-            it('returns true if the user is set and is present in the adminStore with a true flag', function () {
-                authStateChangedCallback({uid: 123});
-                adminStoreMock[123] = true;
-                expect(subject.isAdmin()).toBeTruthy();
-            });
-        });
+      inject(function(authState, _$firebaseAuthService_) {
+        subject = authState;
+      });
     });
-}());
+
+    describe("isLoggedIn", function() {
+      it("returns false before the auth state has changed", function() {
+        expect(subject.isLoggedIn()).toBeFalsy();
+      });
+
+      it("returns false if the user is present without an id", function() {
+        authStateChangedCallback({});
+        expect(subject.isLoggedIn()).toBeFalsy();
+      });
+
+      it("returns false if the user is present with a null id", function() {
+        authStateChangedCallback({ uid: null });
+        expect(subject.isLoggedIn()).toBeFalsy();
+      });
+
+      it("returns true if the user is present with an id", function() {
+        authStateChangedCallback({ uid: 123 });
+        expect(subject.isLoggedIn()).toBeTruthy();
+      });
+    });
+
+    describe("isAdmin", function() {
+      it("returns false before the auth state has changed", function() {
+        expect(subject.isAdmin()).toBeFalsy();
+      });
+
+      it("returns false if the user is present without an id", function() {
+        authStateChangedCallback({});
+        expect(subject.isAdmin()).toBeFalsy();
+      });
+
+      it("returns false if the user is present with a null id", function() {
+        authStateChangedCallback({ uid: null });
+        expect(subject.isAdmin()).toBeFalsy();
+      });
+
+      it("returns false if the user is set but not present in the adminStore", function() {
+        authStateChangedCallback({ uid: 123 });
+        expect(subject.isAdmin()).toBeFalsy();
+      });
+
+      it("returns false if the user is set and is present in the adminStore with a false flag", function() {
+        authStateChangedCallback({ uid: 123 });
+        adminStoreMock[123] = false;
+        expect(subject.isAdmin()).toBeFalsy();
+      });
+
+      it("returns true if the user is set and is present in the adminStore with a true flag", function() {
+        authStateChangedCallback({ uid: 123 });
+        adminStoreMock[123] = true;
+        expect(subject.isAdmin()).toBeTruthy();
+      });
+    });
+  });
+})();

--- a/src/auth/login.controller.js
+++ b/src/auth/login.controller.js
@@ -1,38 +1,35 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  angular.module("movieClub").controller("LoginController", LoginController);
 
-    angular
-        .module('movieClub')
-        .controller('LoginController', LoginController);
+  function LoginController($state, authApi) {
+    var vm = this;
 
-    function LoginController($state, authApi) {
-        var vm = this;
+    // vars
+    vm.isSubmitting = false;
+    vm.hasLoginFailed = false;
 
-        // vars
-        vm.isSubmitting = false;
-        vm.hasLoginFailed = false;
+    // funcs
+    vm.login = login;
 
-        // funcs
-        vm.login = login;
+    function login() {
+      if (!vm.loginForm.$valid) {
+        return;
+      }
 
-        function login() {
-            if (!vm.loginForm.$valid) {
-                return;
-            }
+      vm.isSubmitting = true;
+      vm.hasLoginFailed = false;
 
-            vm.isSubmitting = true;
-            vm.hasLoginFailed = false;
-
-            authApi.login(vm.email, vm.password)
-                .then(function () {
-                    $state.go('dashboard');
-                })
-                .catch(function () {
-                    vm.password = '';
-                    vm.isSubmitting = false;
-                    vm.hasLoginFailed = true;
-                });
-        }
+      authApi
+        .login(vm.email, vm.password)
+        .then(function() {
+          $state.go("dashboard");
+        })
+        .catch(function() {
+          vm.password = "";
+          vm.isSubmitting = false;
+          vm.hasLoginFailed = true;
+        });
     }
-
-}(window.angular));
+  }
+})(window.angular);

--- a/src/auth/logout.controller.js
+++ b/src/auth/logout.controller.js
@@ -1,12 +1,8 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  angular.module("movieClub").controller("LogoutController", LogoutController);
 
-    angular
-        .module('movieClub')
-        .controller('LogoutController', LogoutController);
-
-    function LogoutController(authApi) {
-        authApi.logout();
-    }
-
-}(window.angular));
+  function LogoutController(authApi) {
+    authApi.logout();
+  }
+})(window.angular);

--- a/src/auth/register.controller.js
+++ b/src/auth/register.controller.js
@@ -1,42 +1,40 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  angular
+    .module("movieClub")
+    .controller("RegisterController", RegisterController);
 
-    angular
-        .module('movieClub')
-        .controller('RegisterController', RegisterController);
+  function RegisterController($state, authApi, users) {
+    var vm = this;
 
-    function RegisterController($state, authApi, users) {
-        var vm = this;
+    // vars
+    vm.isSubmitting = false;
+    vm.hasRegistrationFailed = false;
+    vm.usernames = _.map(users, "username");
 
-        // vars
-        vm.isSubmitting = false;
-        vm.hasRegistrationFailed = false;
-        vm.usernames = _.map(users, 'username');
+    // funcs
+    vm.register = register;
 
-        // funcs
-        vm.register = register;
+    function register() {
+      if (!vm.registrationForm.$valid) {
+        return;
+      }
 
-        function register() {
+      vm.isSubmitting = true;
+      vm.hasRegistrationFailed = false;
 
-            if (!vm.registrationForm.$valid) {
-                return;
-            }
-
-            vm.isSubmitting = true;
-            vm.hasRegistrationFailed = false;
-
-            authApi.register(vm.username, vm.email, vm.password)
-                .then(function () {
-                    $state.go('dashboard');
-                })
-                .catch(function () {
-                    vm.password = '';
-                    vm.hasRegistrationFailed = true;
-                })
-                .finally(function () {
-                    vm.isSubmitting = false;
-                });
-        }
+      authApi
+        .register(vm.username, vm.email, vm.password)
+        .then(function() {
+          $state.go("dashboard");
+        })
+        .catch(function() {
+          vm.password = "";
+          vm.hasRegistrationFailed = true;
+        })
+        .finally(function() {
+          vm.isSubmitting = false;
+        });
     }
-
-}(window.angular));
+  }
+})(window.angular);

--- a/src/dashboard/dashboard.controller.js
+++ b/src/dashboard/dashboard.controller.js
@@ -1,15 +1,13 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  angular
+    .module("movieClub")
+    .controller("DashboardController", DashboardController);
 
-    angular
-        .module('movieClub')
-        .controller('DashboardController', DashboardController);
-
-    function DashboardController(currentMovie, propertyStore, users) {
-        var vm = this;
-        vm.currentMovie = currentMovie;
-        vm.propertyStore = propertyStore;
-        vm.users = users;
-    }
-
-}(window.angular));
+  function DashboardController(currentMovie, propertyStore, users) {
+    var vm = this;
+    vm.currentMovie = currentMovie;
+    vm.propertyStore = propertyStore;
+    vm.users = users;
+  }
+})(window.angular);

--- a/src/dashboard/dashboard.controller.spec.js
+++ b/src/dashboard/dashboard.controller.spec.js
@@ -1,36 +1,31 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  describe("DashboardController", function() {
+    var subject;
 
-    describe('DashboardController', function () {
-
-        var subject;
-
-        beforeEach(function () {
-            module('movieClub');
-            inject(function ($controller) {
-                subject = $controller('DashboardController', {
-                    currentMovie: 'current movie value',
-                    propertyStore: 'property store value',
-                    users: 'users value'
-                });
-            });
+    beforeEach(function() {
+      module("movieClub");
+      inject(function($controller) {
+        subject = $controller("DashboardController", {
+          currentMovie: "current movie value",
+          propertyStore: "property store value",
+          users: "users value"
         });
-
-        describe('after initialization', function () {
-
-            it('should expose the currentMovie', function () {
-                expect(subject.currentMovie).toEqual('current movie value');
-            });
-
-            it('should expose the propertyStore', function () {
-                expect(subject.propertyStore).toEqual('property store value');
-            });
-
-            it('should expose the users', function () {
-                expect(subject.users).toEqual('users value');
-            });
-        });
+      });
     });
 
-}(window.angular));
+    describe("after initialization", function() {
+      it("should expose the currentMovie", function() {
+        expect(subject.currentMovie).toEqual("current movie value");
+      });
 
+      it("should expose the propertyStore", function() {
+        expect(subject.propertyStore).toEqual("property store value");
+      });
+
+      it("should expose the users", function() {
+        expect(subject.users).toEqual("users value");
+      });
+    });
+  });
+})(window.angular);

--- a/src/dashboard/dashboard.routes.js
+++ b/src/dashboard/dashboard.routes.js
@@ -1,17 +1,12 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").config(appConfig);
 
-    angular
-        .module('movieClub')
-        .config(appConfig);
-
-    function appConfig($stateProvider) {
-
-        $stateProvider
-            .state('dashboard', {
-                controller: 'DashboardController as dashboardVm',
-                templateUrl: 'dashboard/dashboard.html',
-                url: '/'
-            });
-    }
-}());
+  function appConfig($stateProvider) {
+    $stateProvider.state("dashboard", {
+      controller: "DashboardController as dashboardVm",
+      templateUrl: "dashboard/dashboard.html",
+      url: "/"
+    });
+  }
+})();

--- a/src/firebase/firebaseItems.service.js
+++ b/src/firebase/firebaseItems.service.js
@@ -1,37 +1,32 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  var module = angular.module("movieClub");
 
-    var module = angular.module('movieClub');
+  var arrayNames = ["meetings", "userMovies", "users"];
 
-    var arrayNames = [
-        'meetings',
-        'userMovies',
-        'users'
-    ];
+  var objectNames = [
+    "adminStore",
+    "currentMovie",
+    "currentMovieUser",
+    "propertyStore"
+  ];
 
-    var objectNames = [
-        'adminStore',
-        'currentMovie',
-        'currentMovieUser',
-        'propertyStore'
-    ];
+  arrayNames.forEach(function(name) {
+    var factoryFunc = getFactoryFunc("$firebaseArray", name);
+    module.factory(name, factoryFunc);
+  });
 
-    arrayNames.forEach(function (name) {
-        var factoryFunc = getFactoryFunc('$firebaseArray', name);
-        module.factory(name, factoryFunc);
-    });
+  objectNames.forEach(function(name) {
+    var factoryFunc = getFactoryFunc("$firebaseObject", name);
+    module.factory(name, factoryFunc);
+  });
 
-    objectNames.forEach(function (name) {
-        var factoryFunc = getFactoryFunc('$firebaseObject', name);
-        module.factory(name, factoryFunc);
-    });
-
-    function getFactoryFunc(firebaseServiceName, firebaseItemName) {
-        var func = function (firebaseService, firebaseRefFactory) {
-            var ref = firebaseRefFactory.getRef(firebaseItemName);
-            return firebaseService(ref);
-        };
-        func.$inject = [firebaseServiceName, 'firebaseRefFactory'];
-        return func;
-    }
-}());
+  function getFactoryFunc(firebaseServiceName, firebaseItemName) {
+    var func = function(firebaseService, firebaseRefFactory) {
+      var ref = firebaseRefFactory.getRef(firebaseItemName);
+      return firebaseService(ref);
+    };
+    func.$inject = [firebaseServiceName, "firebaseRefFactory"];
+    return func;
+  }
+})();

--- a/src/firebase/firebaseRefFactory.service.js
+++ b/src/firebase/firebaseRefFactory.service.js
@@ -1,22 +1,22 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").factory("firebaseRefFactory", firebaseRefFactory);
 
-    angular
-        .module('movieClub')
-        .factory('firebaseRefFactory', firebaseRefFactory);
+  /* @ngInject */
+  function firebaseRefFactory($firebaseRef) {
+    return {
+      getRef: getRef
+    };
 
-    /* @ngInject */
-    function firebaseRefFactory($firebaseRef) {
-
-        return {
-            getRef: getRef
-        };
-
-        function getRef(path) {
-            var pathSegments = Array.isArray(path) ? path : [path];
-            return _.reduce(pathSegments, function (ref, segment) {
-                return ref.child(segment);
-            }, $firebaseRef.default);
-        }
+    function getRef(path) {
+      var pathSegments = Array.isArray(path) ? path : [path];
+      return _.reduce(
+        pathSegments,
+        function(ref, segment) {
+          return ref.child(segment);
+        },
+        $firebaseRef.default
+      );
     }
-}());
+  }
+})();

--- a/src/firebase/firebaseRefFactory.service.spec.js
+++ b/src/firebase/firebaseRefFactory.service.spec.js
@@ -1,45 +1,42 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  describe("firebaseRefFactory", function() {
+    var $firebaseRef;
+    var subject;
 
-    describe('firebaseRefFactory', function () {
-
-        var $firebaseRef;
-        var subject;
-
-        beforeEach(function () {
-            module('movieClub');
-            inject(function (_$firebaseRef_, firebaseRefFactory) {
-                subject = firebaseRefFactory;
-                $firebaseRef = _$firebaseRef_;
-                spyOn($firebaseRef.default, 'child');
-            });
-        });
-
-        describe('getRef', function () {
-
-            it('gets a reference for a string input', function () {
-                $firebaseRef.default.child.and.returnValue('child reference');
-
-                var result = subject.getRef('string path');
-
-                expect($firebaseRef.default.child).toHaveBeenCalledWith('string path');
-                expect(result).toEqual('child reference');
-            });
-
-            it('gets a reference for an array input', function () {
-                var childRef1 = {'child': jasmine.createSpy('childRef1')};
-                var childRef2 = {'child': jasmine.createSpy('childRef2')};
-                $firebaseRef.default.child.and.returnValue(childRef1);
-                childRef1.child.and.returnValue(childRef2);
-                childRef2.child.and.returnValue('child reference');
-
-                var result = subject.getRef(['child1', 'child2', 'child3']);
-
-                expect($firebaseRef.default.child).toHaveBeenCalledWith('child1');
-                expect(childRef1.child).toHaveBeenCalledWith('child2');
-                expect(childRef2.child).toHaveBeenCalledWith('child3');
-                expect(result).toEqual('child reference');
-            });
-        });
+    beforeEach(function() {
+      module("movieClub");
+      inject(function(_$firebaseRef_, firebaseRefFactory) {
+        subject = firebaseRefFactory;
+        $firebaseRef = _$firebaseRef_;
+        spyOn($firebaseRef.default, "child");
+      });
     });
-}());
+
+    describe("getRef", function() {
+      it("gets a reference for a string input", function() {
+        $firebaseRef.default.child.and.returnValue("child reference");
+
+        var result = subject.getRef("string path");
+
+        expect($firebaseRef.default.child).toHaveBeenCalledWith("string path");
+        expect(result).toEqual("child reference");
+      });
+
+      it("gets a reference for an array input", function() {
+        var childRef1 = { child: jasmine.createSpy("childRef1") };
+        var childRef2 = { child: jasmine.createSpy("childRef2") };
+        $firebaseRef.default.child.and.returnValue(childRef1);
+        childRef1.child.and.returnValue(childRef2);
+        childRef2.child.and.returnValue("child reference");
+
+        var result = subject.getRef(["child1", "child2", "child3"]);
+
+        expect($firebaseRef.default.child).toHaveBeenCalledWith("child1");
+        expect(childRef1.child).toHaveBeenCalledWith("child2");
+        expect(childRef2.child).toHaveBeenCalledWith("child3");
+        expect(result).toEqual("child reference");
+      });
+    });
+  });
+})();

--- a/src/firebase/movieQueueFactory.service.js
+++ b/src/firebase/movieQueueFactory.service.js
@@ -1,25 +1,26 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").factory("movieQueueFactory", movieQueueFactory);
 
-    angular
-        .module('movieClub')
-        .factory('movieQueueFactory', movieQueueFactory);
+  /* @ngInject */
+  function movieQueueFactory(
+    $firebaseArray,
+    $firebaseAuthService,
+    firebaseRefFactory
+  ) {
+    return {
+      getForCurrentUser: getForCurrentUser,
+      getForUserId: getForUserId
+    };
 
-    /* @ngInject */
-    function movieQueueFactory($firebaseArray, $firebaseAuthService, firebaseRefFactory) {
-        return {
-            getForCurrentUser: getForCurrentUser,
-            getForUserId: getForUserId
-        };
-
-        function getForCurrentUser() {
-            var uid = $firebaseAuthService.$getAuth().uid;
-            return getForUserId(uid);
-        }
-
-        function getForUserId(uid) {
-            var ref = firebaseRefFactory.getRef(['userMovies', uid, 'movies']);
-            return $firebaseArray(ref);
-        }
+    function getForCurrentUser() {
+      var uid = $firebaseAuthService.$getAuth().uid;
+      return getForUserId(uid);
     }
-}());
+
+    function getForUserId(uid) {
+      var ref = firebaseRefFactory.getRef(["userMovies", uid, "movies"]);
+      return $firebaseArray(ref);
+    }
+  }
+})();

--- a/src/firebase/movieQueueFactory.service.spec.js
+++ b/src/firebase/movieQueueFactory.service.spec.js
@@ -1,69 +1,74 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  describe("movieQueueFactory", function() {
+    var $firebaseArrayMock;
+    var $firebaseAuthService;
+    var firebaseRefFactory;
+    var subject;
 
-    describe('movieQueueFactory', function () {
+    beforeEach(function() {
+      $firebaseArrayMock = jasmine.createSpy("$firebaseArrayMock");
 
-        var $firebaseArrayMock;
-        var $firebaseAuthService;
-        var firebaseRefFactory;
-        var subject;
+      module("movieClub");
+      module(function($provide) {
+        $provide.value("$firebaseArray", $firebaseArrayMock);
+      });
 
-        beforeEach(function () {
+      inject(function(
+        _$firebaseAuthService_,
+        _firebaseRefFactory_,
+        movieQueueFactory
+      ) {
+        $firebaseAuthService = _$firebaseAuthService_;
+        spyOn($firebaseAuthService, "$getAuth");
 
-            $firebaseArrayMock = jasmine.createSpy('$firebaseArrayMock');
+        firebaseRefFactory = _firebaseRefFactory_;
+        spyOn(firebaseRefFactory, "getRef");
 
-            module('movieClub');
-            module(function ($provide) {
-                $provide.value('$firebaseArray', $firebaseArrayMock);
-            });
-
-            inject(function (_$firebaseAuthService_, _firebaseRefFactory_, movieQueueFactory) {
-                $firebaseAuthService = _$firebaseAuthService_;
-                spyOn($firebaseAuthService, '$getAuth');
-
-                firebaseRefFactory = _firebaseRefFactory_;
-                spyOn(firebaseRefFactory, 'getRef');
-
-                subject = movieQueueFactory;
-            });
-        });
-
-        describe('getForUserId', function () {
-
-            it('returns a firebase array for the movies of the user specified', function () {
-
-                // given
-                firebaseRefFactory.getRef.and.returnValue('fake reference');
-                $firebaseArrayMock.and.returnValue('fake firebase array');
-
-                // when
-                var result = subject.getForUserId('fake user id');
-
-                // then
-                expect(firebaseRefFactory.getRef).toHaveBeenCalledWith(['userMovies', 'fake user id', 'movies']);
-                expect($firebaseArrayMock).toHaveBeenCalledWith('fake reference');
-                expect(result).toEqual('fake firebase array');
-            });
-        });
-
-        describe('getForCurrentUser', function () {
-
-            it('returns a firebase array for the movies for the current user', function() {
-
-                // given
-                $firebaseAuthService.$getAuth.and.returnValue({uid: 'fake uid'});
-                firebaseRefFactory.getRef.and.returnValue('fake reference');
-                $firebaseArrayMock.and.returnValue('fake firebase array');
-
-                // when
-                var result = subject.getForCurrentUser();
-
-                // then
-                expect($firebaseAuthService.$getAuth).toHaveBeenCalled();
-                expect(firebaseRefFactory.getRef).toHaveBeenCalledWith(['userMovies', 'fake uid', 'movies']);
-                expect($firebaseArrayMock).toHaveBeenCalledWith('fake reference');
-                expect(result).toEqual('fake firebase array');
-            });
-        });
+        subject = movieQueueFactory;
+      });
     });
-}());
+
+    describe("getForUserId", function() {
+      it("returns a firebase array for the movies of the user specified", function() {
+        // given
+        firebaseRefFactory.getRef.and.returnValue("fake reference");
+        $firebaseArrayMock.and.returnValue("fake firebase array");
+
+        // when
+        var result = subject.getForUserId("fake user id");
+
+        // then
+        expect(firebaseRefFactory.getRef).toHaveBeenCalledWith([
+          "userMovies",
+          "fake user id",
+          "movies"
+        ]);
+        expect($firebaseArrayMock).toHaveBeenCalledWith("fake reference");
+        expect(result).toEqual("fake firebase array");
+      });
+    });
+
+    describe("getForCurrentUser", function() {
+      it("returns a firebase array for the movies for the current user", function() {
+        // given
+        $firebaseAuthService.$getAuth.and.returnValue({ uid: "fake uid" });
+        firebaseRefFactory.getRef.and.returnValue("fake reference");
+        $firebaseArrayMock.and.returnValue("fake firebase array");
+
+        // when
+        var result = subject.getForCurrentUser();
+
+        // then
+        expect($firebaseAuthService.$getAuth).toHaveBeenCalled();
+        expect(firebaseRefFactory.getRef).toHaveBeenCalledWith([
+          "userMovies",
+          "fake uid",
+          "movies"
+        ]);
+        expect($firebaseArrayMock).toHaveBeenCalledWith("fake reference");
+        expect(result).toEqual("fake firebase array");
+      });
+    });
+  });
+})();

--- a/src/firebase/userFactory.service.js
+++ b/src/firebase/userFactory.service.js
@@ -1,18 +1,19 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").factory("userFactory", userFactory);
 
-    angular
-        .module('movieClub')
-        .factory('userFactory', userFactory);
-
-    /* @ngInject */
-    function userFactory($firebaseAuthService, $firebaseObject, firebaseRefFactory) {
-        return {
-            get: function () {
-                var uid = $firebaseAuthService.$getAuth().uid;
-                var ref = firebaseRefFactory.getRef(['users', uid]);
-                return $firebaseObject(ref);
-            }
-        };
-    }
-}());
+  /* @ngInject */
+  function userFactory(
+    $firebaseAuthService,
+    $firebaseObject,
+    firebaseRefFactory
+  ) {
+    return {
+      get: function() {
+        var uid = $firebaseAuthService.$getAuth().uid;
+        var ref = firebaseRefFactory.getRef(["users", uid]);
+        return $firebaseObject(ref);
+      }
+    };
+  }
+})();

--- a/src/firebase/userFactory.service.spec.js
+++ b/src/firebase/userFactory.service.spec.js
@@ -1,51 +1,53 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  describe("userFactory", function() {
+    var $firebaseAuthService;
+    var $firebaseObjectMock;
+    var firebaseRefFactory;
+    var subject;
 
-    describe('userFactory', function () {
+    beforeEach(function() {
+      $firebaseObjectMock = jasmine.createSpy("$firebaseObjectMock");
 
-        var $firebaseAuthService;
-        var $firebaseObjectMock;
-        var firebaseRefFactory;
-        var subject;
+      module("movieClub");
+      module(function($provide) {
+        $provide.value("$firebaseObject", $firebaseObjectMock);
+      });
 
-        beforeEach(function () {
+      inject(function(
+        _$firebaseAuthService_,
+        _firebaseRefFactory_,
+        userFactory
+      ) {
+        $firebaseAuthService = _$firebaseAuthService_;
+        spyOn($firebaseAuthService, "$getAuth");
 
-            $firebaseObjectMock = jasmine.createSpy('$firebaseObjectMock');
+        firebaseRefFactory = _firebaseRefFactory_;
+        spyOn(firebaseRefFactory, "getRef");
 
-            module('movieClub');
-            module(function ($provide) {
-                $provide.value('$firebaseObject', $firebaseObjectMock);
-            });
-
-            inject(function (_$firebaseAuthService_, _firebaseRefFactory_, userFactory) {
-                $firebaseAuthService = _$firebaseAuthService_;
-                spyOn($firebaseAuthService, '$getAuth');
-
-                firebaseRefFactory = _firebaseRefFactory_;
-                spyOn(firebaseRefFactory, 'getRef');
-
-                subject = userFactory;
-            });
-        });
-
-        describe('get', function () {
-
-            it('returns a firebase object for the current user', function () {
-
-                // given
-                $firebaseAuthService.$getAuth.and.returnValue({uid: 'fake uid'});
-                firebaseRefFactory.getRef.and.returnValue('fake reference');
-                $firebaseObjectMock.and.returnValue('fake firebase object');
-
-                // when
-                var result = subject.get();
-
-                // then
-                expect($firebaseAuthService.$getAuth).toHaveBeenCalled();
-                expect(firebaseRefFactory.getRef).toHaveBeenCalledWith(['users', 'fake uid']);
-                expect($firebaseObjectMock).toHaveBeenCalledWith('fake reference');
-                expect(result).toEqual('fake firebase object');
-            });
-        });
+        subject = userFactory;
+      });
     });
-}());
+
+    describe("get", function() {
+      it("returns a firebase object for the current user", function() {
+        // given
+        $firebaseAuthService.$getAuth.and.returnValue({ uid: "fake uid" });
+        firebaseRefFactory.getRef.and.returnValue("fake reference");
+        $firebaseObjectMock.and.returnValue("fake firebase object");
+
+        // when
+        var result = subject.get();
+
+        // then
+        expect($firebaseAuthService.$getAuth).toHaveBeenCalled();
+        expect(firebaseRefFactory.getRef).toHaveBeenCalledWith([
+          "users",
+          "fake uid"
+        ]);
+        expect($firebaseObjectMock).toHaveBeenCalledWith("fake reference");
+        expect(result).toEqual("fake firebase object");
+      });
+    });
+  });
+})();

--- a/src/nav/nav.component.js
+++ b/src/nav/nav.component.js
@@ -1,18 +1,14 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").component("mcNav", {
+    templateUrl: "nav/nav.html",
+    controller: NavController
+  });
 
-    angular
-        .module('movieClub')
-        .component('mcNav', {
-            templateUrl: 'nav/nav.html',
-            controller: NavController
-        });
-
-    /* @ngInject */
-    function NavController(authState) {
-
-        var vm = this;
-        vm.isAdmin = authState.isAdmin;
-        vm.isLoggedIn = authState.isLoggedIn;
-    }
-}());
+  /* @ngInject */
+  function NavController(authState) {
+    var vm = this;
+    vm.isAdmin = authState.isAdmin;
+    vm.isLoggedIn = authState.isLoggedIn;
+  }
+})();

--- a/src/nav/nav.component.spec.js
+++ b/src/nav/nav.component.spec.js
@@ -1,23 +1,24 @@
-'use strict';
+"use strict";
 
-describe('navComponent', function () {
+describe("navComponent", function() {
+  var authState;
+  var subject;
 
-    var authState;
-    var subject;
+  beforeEach(module("movieClub"));
+  beforeEach(
+    inject(function($componentController, _authState_) {
+      authState = _authState_;
+      subject = $componentController("mcNav", {
+        authState: authState
+      });
+    })
+  );
 
-    beforeEach(module('movieClub'));
-    beforeEach(inject(function ($componentController, _authState_) {
-        authState = _authState_;
-        subject = $componentController('mcNav', {
-            authState: authState
-        });
-    }));
+  it("exposes the authState.isAdmin function", function() {
+    expect(subject.isAdmin).toBe(authState.isAdmin);
+  });
 
-    it('exposes the authState.isAdmin function', function () {
-        expect(subject.isAdmin).toBe(authState.isAdmin);
-    });
-
-    it('exposes the authState.isLoggedIn function', function () {
-        expect(subject.isLoggedIn).toBe(authState.isLoggedIn);
-    });
+  it("exposes the authState.isLoggedIn function", function() {
+    expect(subject.isLoggedIn).toBe(authState.isLoggedIn);
+  });
 });

--- a/src/user/myMovies/myMovies.controller.js
+++ b/src/user/myMovies/myMovies.controller.js
@@ -1,71 +1,77 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  angular
+    .module("movieClub")
+    .controller("MyMoviesController", MyMoviesController);
 
-    angular
-        .module('movieClub')
-        .controller('MyMoviesController', MyMoviesController);
+  function MyMoviesController(movieQueueFactory, youtubeValidator) {
+    var vm = this;
+    vm.movies = movieQueueFactory.getForCurrentUser();
+    vm.isSubmitting = false;
+    vm.addMovie = addMovie;
+    vm.watchTrailer = watchTrailer;
+    vm.removeMovie = removeMovie;
+    vm.moveDown = moveDown;
+    vm.moveUp = moveUp;
+    vm.validateMovieData = validateMovieData;
+    vm.newMovieName = "";
+    vm.newMovieTrailer = "";
 
-    function MyMoviesController(movieQueueFactory, youtubeValidator) {
-        var vm = this;
-        vm.movies = movieQueueFactory.getForCurrentUser();
-        vm.isSubmitting = false;
-        vm.addMovie = addMovie;
-        vm.watchTrailer = watchTrailer;
-        vm.removeMovie = removeMovie;
-        vm.moveDown = moveDown;
-        vm.moveUp = moveUp;
-        vm.validateMovieData = validateMovieData;
-        vm.newMovieName = '';
-        vm.newMovieTrailer = '';
-
-        function addMovie() {
-            vm.movies.$add({name: vm.newMovieName, trailerUrl: vm.newMovieTrailer, order: vm.movies.length});
-            vm.newMovieName = '';
-            vm.newMovieTrailer = '';
-        }
-
-        function watchTrailer(movie) {
-            vm.selectedTrailer = movie.trailerUrl;
-        }
-
-        function removeMovie(movie) {
-            vm.movies.$remove(movie).then(function () {
-                _(vm.movies)
-                    .sortBy('order')
-                    .forEach(function (movie, index) {
-                        movie.order = index;
-                        vm.movies.$save(movie);
-                    })
-                    .value();
-            });
-        }
-
-        function moveDown(movie) {
-            var movieBelow = _.find(vm.movies, {order: movie.order + 1});
-            swapMovies(movie, movieBelow);
-        }
-
-        function moveUp(movie) {
-            var movieAbove = _.find(vm.movies, {order: movie.order - 1});
-            swapMovies(movie, movieAbove);
-        }
-
-        function swapMovies(movieA, movieB) {
-            var tempOrder = movieA.order;
-            movieA.order = movieB.order;
-            movieB.order = tempOrder;
-
-            vm.movies.$save(movieA);
-            vm.movies.$save(movieB);
-        }
-
-        function validateMovieData() {
-            var url = vm.newMovieTrailer;
-            var name = vm.newMovieName;
-            if (name && name.length > 0 && (!url || url.length === 0 || youtubeValidator.getYoutubeId(url))) {
-                return true;
-            }
-        }
+    function addMovie() {
+      vm.movies.$add({
+        name: vm.newMovieName,
+        trailerUrl: vm.newMovieTrailer,
+        order: vm.movies.length
+      });
+      vm.newMovieName = "";
+      vm.newMovieTrailer = "";
     }
 
-}(window.angular));
+    function watchTrailer(movie) {
+      vm.selectedTrailer = movie.trailerUrl;
+    }
+
+    function removeMovie(movie) {
+      vm.movies.$remove(movie).then(function() {
+        _(vm.movies)
+          .sortBy("order")
+          .forEach(function(movie, index) {
+            movie.order = index;
+            vm.movies.$save(movie);
+          })
+          .value();
+      });
+    }
+
+    function moveDown(movie) {
+      var movieBelow = _.find(vm.movies, { order: movie.order + 1 });
+      swapMovies(movie, movieBelow);
+    }
+
+    function moveUp(movie) {
+      var movieAbove = _.find(vm.movies, { order: movie.order - 1 });
+      swapMovies(movie, movieAbove);
+    }
+
+    function swapMovies(movieA, movieB) {
+      var tempOrder = movieA.order;
+      movieA.order = movieB.order;
+      movieB.order = tempOrder;
+
+      vm.movies.$save(movieA);
+      vm.movies.$save(movieB);
+    }
+
+    function validateMovieData() {
+      var url = vm.newMovieTrailer;
+      var name = vm.newMovieName;
+      if (
+        name &&
+        name.length > 0 &&
+        (!url || url.length === 0 || youtubeValidator.getYoutubeId(url))
+      ) {
+        return true;
+      }
+    }
+  }
+})(window.angular);

--- a/src/user/myMovies/myMovies.routes.js
+++ b/src/user/myMovies/myMovies.routes.js
@@ -1,17 +1,12 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").config(appConfig);
 
-    angular
-        .module('movieClub')
-        .config(appConfig);
-
-    function appConfig($stateProvider) {
-
-        $stateProvider
-            .state('user.myMovies', {
-                controller: 'MyMoviesController as myMoviesVm',
-                templateUrl: 'user/myMovies/myMovies.html',
-                url: '/user/my-movies'
-            });
-    }
-}());
+  function appConfig($stateProvider) {
+    $stateProvider.state("user.myMovies", {
+      controller: "MyMoviesController as myMoviesVm",
+      templateUrl: "user/myMovies/myMovies.html",
+      url: "/user/my-movies"
+    });
+  }
+})();

--- a/src/user/user.routes.js
+++ b/src/user/user.routes.js
@@ -1,21 +1,16 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  angular.module("movieClub").config(appConfig);
 
-    angular
-        .module('movieClub')
-        .config(appConfig);
-
-    function appConfig($stateProvider) {
-
-        $stateProvider
-            .state('user', {
-                abstract: true,
-                template: '<ui-view/>',
-                resolve: {
-                    currentAuth: function ($firebaseAuthService) {
-                        return $firebaseAuthService.$requireSignIn();
-                    }
-                }
-            });
-    }
-}());
+  function appConfig($stateProvider) {
+    $stateProvider.state("user", {
+      abstract: true,
+      template: "<ui-view/>",
+      resolve: {
+        currentAuth: function($firebaseAuthService) {
+          return $firebaseAuthService.$requireSignIn();
+        }
+      }
+    });
+  }
+})();

--- a/src/youtube/youtube.directive.js
+++ b/src/youtube/youtube.directive.js
@@ -1,38 +1,37 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  angular.module("movieClub").directive("youtube", youtube);
 
-    angular.module('movieClub')
-           .directive('youtube', youtube);
+  function youtube() {
+    return {
+      restriction: "EA",
+      scope: {
+        videoUrl: "=",
+        autoPlay: "@",
+        width: "@",
+        height: "@"
+      },
+      controller: function($scope, youtubeValidator) {
+        $scope.getIframeSrc = getIframeSrc;
+        $scope.width = $scope.width || 560;
+        $scope.height = $scope.height || 315;
 
-    function youtube() {
-        return {
-            restriction: 'EA',
-            scope: {
-                videoUrl: '=',
-                autoPlay: '@',
-                width: '@',
-                height: '@'
-            },
-            controller: function($scope, youtubeValidator) {
-                $scope.getIframeSrc = getIframeSrc;
-                $scope.width = $scope.width || 560;
-                $scope.height = $scope.height || 315;
-
-                function getIframeSrc(videoUrl) {
-                    var embedUrl = 'https://www.youtube.com/embed/' + youtubeValidator.getYoutubeId(videoUrl);
-                    if ($scope.autoPlay) {
-                        embedUrl += '?autoplay=1';
-                    }
-                    return embedUrl;
-                }
-            },
-            template: '<iframe width="{{width}}"' +
-                               'height="{{height}}"' +
-                               'ng-src="{{getIframeSrc(videoUrl)}}"' +
-                               'frameborder="0"' +
-                               'allowfullscreen>' +
-                      '</iframe>'
-        };
-    }
-
-}(window.angular));
+        function getIframeSrc(videoUrl) {
+          var embedUrl =
+            "https://www.youtube.com/embed/" +
+            youtubeValidator.getYoutubeId(videoUrl);
+          if ($scope.autoPlay) {
+            embedUrl += "?autoplay=1";
+          }
+          return embedUrl;
+        }
+      },
+      template: '<iframe width="{{width}}"' +
+        'height="{{height}}"' +
+        'ng-src="{{getIframeSrc(videoUrl)}}"' +
+        'frameborder="0"' +
+        "allowfullscreen>" +
+        "</iframe>"
+    };
+  }
+})(window.angular);

--- a/src/youtube/youtubeValidator.service.js
+++ b/src/youtube/youtubeValidator.service.js
@@ -1,25 +1,21 @@
-(function (angular) {
-    'use strict';
+(function(angular) {
+  "use strict";
+  angular.module("movieClub").factory("youtubeValidator", youtubeValidator);
 
-    angular
-        .module('movieClub')
-        .factory('youtubeValidator', youtubeValidator);
+  function youtubeValidator() {
+    var factory = {
+      getYoutubeId: getYoutubeId
+    };
+    return factory;
 
-    function youtubeValidator() {
-        var factory = {
-            getYoutubeId: getYoutubeId
-        };
-        return factory;
-
-        function getYoutubeId(url) {
-            if (url && url.length > 0) {
-                var regExp = /.*(?:youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=)([^#\&\?]*).*/;
-                var match = url.match(regExp);
-                if (match && match[1].length === 11) {
-                    return match[1];
-                }
-            }
+    function getYoutubeId(url) {
+      if (url && url.length > 0) {
+        var regExp = /.*(?:youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=)([^#\&\?]*).*/;
+        var match = url.match(regExp);
+        if (match && match[1].length === 11) {
+          return match[1];
         }
+      }
     }
-
-}(window.angular));
+  }
+})(window.angular);

--- a/src/youtube/youtubeValidator.service.spec.js
+++ b/src/youtube/youtubeValidator.service.spec.js
@@ -1,33 +1,35 @@
-(function () {
-    'use strict';
+(function() {
+  "use strict";
+  describe("youtubeValidator", function() {
+    var youtubeValidator;
 
-    describe('youtubeValidator', function () {
+    beforeEach(module("movieClub"));
+    beforeEach(
+      inject(function(_youtubeValidator_) {
+        youtubeValidator = _youtubeValidator_;
+      })
+    );
 
-        var youtubeValidator;
+    describe("getYoutubeId", function() {
+      it("return NULL when URL is NULL", function() {
+        expect(youtubeValidator.getYoutubeId(null)).toBe(undefined);
+      });
 
-        beforeEach(module('movieClub'));
-        beforeEach(inject(function (_youtubeValidator_) {
-            youtubeValidator = _youtubeValidator_;
-        }));
+      it("return NULL when URL is an empty string", function() {
+        expect(youtubeValidator.getYoutubeId("")).toBe(undefined);
+      });
 
-        describe('getYoutubeId', function () {
+      it("return NULL when URL is not a valid youtube URL", function() {
+        expect(youtubeValidator.getYoutubeId("www.google.com")).toBe(undefined);
+      });
 
-            it('return NULL when URL is NULL', function () {
-                expect(youtubeValidator.getYoutubeId(null)).toBe(undefined);
-            });
-
-            it('return NULL when URL is an empty string', function () {
-                expect(youtubeValidator.getYoutubeId('')).toBe(undefined);
-            });
-
-            it('return NULL when URL is not a valid youtube URL', function () {
-                expect(youtubeValidator.getYoutubeId('www.google.com')).toBe(undefined);
-            });
-
-            it('return YouTube video ID when passed a valid youtube URL', function () {
-                expect(youtubeValidator.getYoutubeId('https://www.youtube.com/watch?v=UhhCdJY3KMw'))
-                    .toBe('UhhCdJY3KMw');
-            });
-        });
+      it("return YouTube video ID when passed a valid youtube URL", function() {
+        expect(
+          youtubeValidator.getYoutubeId(
+            "https://www.youtube.com/watch?v=UhhCdJY3KMw"
+          )
+        ).toBe("UhhCdJY3KMw");
+      });
     });
-}());
+  });
+})();


### PR DESCRIPTION
Removes the grunt tasks for jshint and jscs in favor of running [prettier](https://github.com/prettier/prettier) as a pre-commit hook. Runs prettier on all *.js files.